### PR TITLE
`/self-reflection`ページにおいて画像が表示されない問題

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## リポジトリ
+
+GitHub: https://github.com/hiroshimaeasyryo/kanpai_lp_new
+
 ## プロジェクト概要
 
 KANPAI就活のランディングページ（LP）サイト。複数LPをスラグベースで管理でき、コンテンツマネージャー画面からLP内容を編集・デプロイできる。

--- a/client/src/pages/SelfReflection.tsx
+++ b/client/src/pages/SelfReflection.tsx
@@ -52,7 +52,7 @@ const DEFAULT_CONTENT: SelfReflectionContent = {
     titleHtml: "面接のたびに、<br>自分を取り繕うことに<br>慣れていませんか。",
     sub: "言葉にならないのは、考えが足りないからじゃない。",
     ctaLabel: "日帰り自己分析合宿に申し込む",
-    bgImageUrl: "/self_reflection/hero.jpg",
+    bgImageUrl: "/self_reflection/hero.png",
   },
   eventInfo: {
     label: "次回開催",
@@ -150,7 +150,7 @@ const DEFAULT_CONTENT: SelfReflectionContent = {
     ],
   },
   advisor: {
-    photoUrl: "/self_reflection/advisor.jpg",
+    photoUrl: "/self_reflection/advisor.png",
     name: "堺 千菜美",
     title: "株式会社ワークアズライフ｜キャリアアドバイザー",
     bio: [


### PR DESCRIPTION
## 概要
`/self-reflection` ページで hero 画像と advisor 画像が表示されない問題を修正。

## 対応内容
- `SelfReflection.tsx` の画像パス拡張子を修正
  - `hero.jpg` → `hero.png`
  - `advisor.jpg` → `advisor.png`
- 実際のファイルは `.png` だがコード上で `.jpg` と指定していたことが原因

close #5