### PR TITLE
fix: /self-stance で保存した文字色・フォントが反映されない問題を修正 (#16)

### DIFF
--- a/client/src/components/contents-manager/CmId.tsx
+++ b/client/src/components/contents-manager/CmId.tsx
@@ -1,4 +1,31 @@
-import type { CSSProperties, ElementType, ReactNode } from "react";
+import { createContext, useContext, type CSSProperties, type ElementType, type ReactNode } from "react";
+import { fieldStyleToCss, type HomeCopyFieldStyles } from "@/types/home-copy-style";
+
+/**
+ * data-cm-id ごとの装飾（fieldStyles）をページ全体に供給するコンテキスト。
+ * LP/構造化ページ側で <FieldStylesProvider value={content.fieldStyles}> で包むと、
+ * 配下の CmId / CmHtml が対応する装飾を自動適用する。
+ * Provider 外（管理画面のエディタ等）では既定の空マップとなり、従来挙動を維持する。
+ */
+const FieldStylesContext = createContext<HomeCopyFieldStyles | undefined>(undefined);
+
+export function FieldStylesProvider({
+  value,
+  children,
+}: {
+  value?: HomeCopyFieldStyles;
+  children: ReactNode;
+}) {
+  return <FieldStylesContext.Provider value={value}>{children}</FieldStylesContext.Provider>;
+}
+
+/** コンテキストの fieldStyles と明示 style をマージ（明示 style を優先） */
+function useCmStyle(id: string, style?: CSSProperties): CSSProperties | undefined {
+  const fieldStyles = useContext(FieldStylesContext);
+  const fromField = fieldStyleToCss(fieldStyles?.[id]);
+  if (Object.keys(fromField).length === 0) return style;
+  return { ...fromField, ...style };
+}
 
 /** プレビュー選択用 data-cm-id ラッパー */
 export function CmId({
@@ -14,8 +41,9 @@ export function CmId({
   style?: CSSProperties;
   children?: ReactNode;
 }) {
+  const merged = useCmStyle(id, style);
   return (
-    <Tag data-cm-id={id} className={className} style={style}>
+    <Tag data-cm-id={id} className={className} style={merged}>
       {children}
     </Tag>
   );
@@ -34,11 +62,12 @@ export function CmHtml({
   className?: string;
   style?: CSSProperties;
 }) {
+  const merged = useCmStyle(id, style);
   return (
     <Tag
       data-cm-id={id}
       className={className}
-      style={style}
+      style={merged}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/client/src/pages/SelfStance.tsx
+++ b/client/src/pages/SelfStance.tsx
@@ -10,7 +10,7 @@ import {
   type SelfStanceContent,
 } from "@/types/self-stance";
 import { EventInfoIcon } from "@/components/EventInfoIcon";
-import { CmId, CmHtml } from "@/components/contents-manager/CmId";
+import { CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import "./self-stance.css";
 
 const STORAGE_KEY = "self_stance_content_v1";
@@ -169,6 +169,7 @@ export default function SelfStance() {
   const c = content;
 
   return (
+    <FieldStylesProvider value={c.fieldStyles}>
     <div id="self-stance-page">
       <div className="sticky">
         <a
@@ -535,5 +536,6 @@ export default function SelfStance() {
         <CmId id="ss-footer-copyright">{c.footer.copyright}</CmId>
       </footer>
     </div>
+    </FieldStylesProvider>
   );
 }

--- a/client/src/types/self-stance.ts
+++ b/client/src/types/self-stance.ts
@@ -1,7 +1,7 @@
 /** /self-stance 専用コンテンツ（ContentPayload.selfStance） */
 
 import seed from "../../public/content/self-stance.json";
-import type { HomeCopyFieldStyles } from "@/types/home-copy-style";
+import type { HomeCopyFieldStyles, TextFieldStyle } from "@/types/home-copy-style";
 
 export const SELF_STANCE_ASSETS = {
   favicon: "/self_stance/favicon.png",
@@ -111,9 +111,41 @@ function mergeDeep(target: Record<string, unknown>, source: Record<string, unkno
   }
 }
 
+/**
+ * fieldStyles は要素ID（ss-*）をキーにした動的マップ。
+ * mergeDeep は `if (!(k in target)) continue` のため、デフォルトseedに無い
+ * 新規キー（新たに装飾した要素）を破棄してしまう。そのためここで個別にマージし、
+ * 動的キーを保持する（home-copy の mergeFieldStylesFromRaw と同方針）。
+ */
+function mergeFieldStyles(
+  raw: unknown,
+  base?: HomeCopyFieldStyles,
+): HomeCopyFieldStyles | undefined {
+  if (!raw || typeof raw !== "object") return base;
+  const out: HomeCopyFieldStyles = { ...(base ?? {}) };
+  for (const [id, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (!val || typeof val !== "object") continue;
+    const o = val as Record<string, unknown>;
+    const prev: TextFieldStyle = out[id] ?? {};
+    out[id] = {
+      fontSize: typeof o.fontSize === "string" ? o.fontSize : prev.fontSize,
+      color: typeof o.color === "string" ? o.color : prev.color,
+      fontFamily: typeof o.fontFamily === "string" ? o.fontFamily : prev.fontFamily,
+      href: typeof o.href === "string" ? o.href : prev.href,
+    };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export function mergeSelfStanceContent(raw: unknown): SelfStanceContent {
   const d = cloneDefault();
   if (!raw || typeof raw !== "object") return d;
   mergeDeep(d as unknown as Record<string, unknown>, raw as Record<string, unknown>);
+  // mergeDeep が動的キーを落とすため、fieldStyles は専用ロジックで上書きマージする
+  const merged = mergeFieldStyles(
+    (raw as Record<string, unknown>).fieldStyles,
+    d.fieldStyles,
+  );
+  if (merged) d.fieldStyles = merged;
   return d;
 }


### PR DESCRIPTION
## 概要
issue #16 の対応。contents-manager で装飾（文字色・フォント）を編集・保存しても `/self-stance` の公開ページに反映されない問題を修正します。

## 原因
1. **公開ページが装飾を適用していなかった** — `SelfStance.tsx` は `CmId`/`CmHtml` を45箇所使用しているが `content.fieldStyles` を一切読み取っておらず、保存値が表示に反映されていなかった（Home/LP ページは `cms()` ヘルパーで適用済みだが self-stance のみ実装漏れ）。
2. **マージが新規キーを破棄していた** — `mergeSelfStanceContent` の `mergeDeep` が `if (!(k in target)) continue` のため、ビルド時seedに無い新規の `fieldStyles` キー（新たに装飾した要素）を捨てていた。

## 変更
- `components/contents-manager/CmId.tsx`: `FieldStylesProvider` コンテキストを追加。配下の `CmId`/`CmHtml` が `fieldStyles` を自動適用（45箇所を個別編集せず対応。エディタ側はProvider外のため従来挙動を維持）。
- `pages/SelfStance.tsx`: ページ全体を `<FieldStylesProvider value={content.fieldStyles}>` で包む。
- `types/self-stance.ts`: `fieldStyles` を専用ロジックで上書きマージし、動的キーを保持（home-copy と同方針）。

## 検証
- [x] `pnpm check`（型チェック）パス
- [x] `vite build` 成功
- [x] 実ページで `ss-sticky-cta-label` が保存値 `#f03c00`（`rgb(240,60,0)`）で反映。他の `#5D4037` カラー・フォント上書き（Zen Kaku Gothic New / Noto Serif JP）も反映を確認
- [x] 管理画面ライブプレビュー（onDraft 経路）も同じマージを通るため編集中もリアルタイム反映

## 補足
本PRは `/self-stance` の `fieldStyles` 反映に絞った修正です。issue #16 で挙がっている他LP（btob_seminar / starting_job_hunting 等）も同種の `mergeDeep` を使っているため、必要なら別PRで横展開します。

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)