### PR TITLE
feat: contents-manager から要素の背景色をカスタマイズ可能に

### DIFF
--- a/client/src/components/contents-manager/CmId.tsx
+++ b/client/src/components/contents-manager/CmId.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, type CSSProperties, type ElementType, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type ElementType,
+  type ReactNode,
+} from "react";
 import { fieldStyleToCss, type HomeCopyFieldStyles } from "@/types/home-copy-style";
 
 /**
@@ -27,23 +34,27 @@ function useCmStyle(id: string, style?: CSSProperties): CSSProperties | undefine
   return { ...fromField, ...style };
 }
 
-/** プレビュー選択用 data-cm-id ラッパー */
-export function CmId({
-  id,
-  as: Tag = "span",
-  className,
-  style,
-  children,
-}: {
+type CmIdProps<T extends ElementType = "span"> = {
   id: string;
-  as?: ElementType;
+  as?: T;
   className?: string;
   style?: CSSProperties;
   children?: ReactNode;
-}) {
+} & Omit<ComponentPropsWithoutRef<T>, "id" | "as" | "style" | "className" | "children">;
+
+/** プレビュー選択用 data-cm-id ラッパー */
+export function CmId<T extends ElementType = "span">({
+  id,
+  as,
+  className,
+  style,
+  children,
+  ...rest
+}: CmIdProps<T>) {
+  const Tag = (as ?? "span") as ElementType;
   const merged = useCmStyle(id, style);
   return (
-    <Tag data-cm-id={id} className={className} style={merged}>
+    <Tag data-cm-id={id} className={className} style={merged} {...rest}>
       {children}
     </Tag>
   );

--- a/client/src/components/contents-manager/TextElementEditor.tsx
+++ b/client/src/components/contents-manager/TextElementEditor.tsx
@@ -23,6 +23,40 @@ import * as SliderPrimitive from "@radix-ui/react-slider";
 const fieldCls = "mt-1 border-[#ffd7c3]";
 const labelCls = "text-[#3D281E]";
 
+function ColorField({
+  label,
+  value,
+  placeholder,
+  defaultPickerColor,
+  onChange,
+}: {
+  label: string;
+  value?: string;
+  placeholder: string;
+  defaultPickerColor: string;
+  onChange: (color: string) => void;
+}) {
+  return (
+    <div>
+      <Label className={labelCls}>{label}</Label>
+      <div className="flex gap-2 mt-1">
+        <Input
+          type="color"
+          value={value?.startsWith("#") ? value : defaultPickerColor}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10 w-12 p-1 border-[#ffd7c3] cursor-pointer"
+        />
+        <Input
+          value={value ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={`${fieldCls} flex-1`}
+        />
+      </div>
+    </div>
+  );
+}
+
 type Props = {
   text: string;
   onTextChange: (value: string) => void;
@@ -112,23 +146,21 @@ export function TextElementEditor({
           />
         </div>
 
-        <div>
-          <Label className={labelCls}>テキストカラー</Label>
-          <div className="flex gap-2 mt-1">
-            <Input
-              type="color"
-              value={style?.color?.startsWith("#") ? style.color : "#3D281E"}
-              onChange={(e) => onStyleChange({ color: e.target.value })}
-              className="h-10 w-12 p-1 border-[#ffd7c3] cursor-pointer"
-            />
-            <Input
-              value={style?.color ?? ""}
-              onChange={(e) => onStyleChange({ color: e.target.value })}
-              placeholder="#3D281E"
-              className={`${fieldCls} flex-1`}
-            />
-          </div>
-        </div>
+        <ColorField
+          label="テキストカラー"
+          value={style?.color}
+          placeholder="#3D281E"
+          defaultPickerColor="#3D281E"
+          onChange={(color) => onStyleChange({ color })}
+        />
+
+        <ColorField
+          label="背景色"
+          value={style?.backgroundColor}
+          placeholder="未設定（LP既定）"
+          defaultPickerColor="#3D281E"
+          onChange={(backgroundColor) => onStyleChange({ backgroundColor })}
+        />
 
         <div>
           <Label className={labelCls}>テキストフォント</Label>

--- a/client/src/pages/SelfStance.tsx
+++ b/client/src/pages/SelfStance.tsx
@@ -62,6 +62,23 @@ function CtaButton({
   className?: string;
   showLineIcon?: boolean;
 }) {
+  if (labelCmId) {
+    return (
+      <CmId
+        id={labelCmId}
+        as="a"
+        href={href}
+        className={className}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={trackMetaPixelLead}
+      >
+        {showLineIcon && <LineIcon />}
+        {label}
+      </CmId>
+    );
+  }
+
   return (
     <a
       href={href}
@@ -71,7 +88,7 @@ function CtaButton({
       onClick={trackMetaPixelLead}
     >
       {showLineIcon && <LineIcon />}
-      {labelCmId ? <CmId id={labelCmId}>{label}</CmId> : label}
+      {label}
     </a>
   );
 }
@@ -172,15 +189,17 @@ export default function SelfStance() {
     <FieldStylesProvider value={c.fieldStyles}>
     <div id="self-stance-page">
       <div className="sticky">
-        <a
+        <CmId
+          id="ss-sticky-cta-label"
+          as="a"
           href={c.stickyCta.ctaHref}
           target="_blank"
           rel="noopener noreferrer"
           onClick={trackMetaPixelLead}
         >
           <LineIcon />
-          <CmId id="ss-sticky-cta-label">{c.stickyCta.label}</CmId>
-        </a>
+          {c.stickyCta.label}
+        </CmId>
       </div>
 
       <header className="site-header">
@@ -194,18 +213,18 @@ export default function SelfStance() {
           <CmId id="ss-header-logo-alt" className="sr-only">
             {c.header.logoAlt}
           </CmId>
-          <a
+          <CmId
+            id="ss-header-cta-label"
+            as="a"
             href={c.header.ctaHref}
             className="header-btn"
             target="_blank"
             rel="noopener noreferrer"
             onClick={trackMetaPixelLead}
           >
-            <CmId id="ss-header-cta-label" as="span">
-              {c.header.ctaLabel}
-            </CmId>
+            {c.header.ctaLabel}
             <LineIcon />
-          </a>
+          </CmId>
         </div>
       </header>
       <div className="deco-line" />

--- a/client/src/types/home-copy-style.ts
+++ b/client/src/types/home-copy-style.ts
@@ -1,12 +1,14 @@
 import type { CSSProperties } from "react";
 
-/** 要素ID（data-cm-id）ごとのテキスト装飾 */
+/** 要素ID（data-cm-id）ごとの装飾（テキスト・背景など） */
 export type TextFieldStyle = {
   fontSize?: string;
   color?: string;
   fontFamily?: string;
   /** リンク要素向け。空ならLP既定の遷移先を使用 */
   href?: string;
+  /** 背景色。空ならLP既定のCSSを使用 */
+  backgroundColor?: string;
 };
 
 export type HomeCopyFieldStyles = Record<string, TextFieldStyle>;
@@ -42,7 +44,40 @@ export function fieldStyleToCss(style?: TextFieldStyle): CSSProperties {
   if (style.fontSize?.trim()) out.fontSize = style.fontSize.trim();
   if (style.color?.trim()) out.color = style.color.trim();
   if (style.fontFamily?.trim()) out.fontFamily = style.fontFamily.trim();
+  if (style.backgroundColor?.trim()) {
+    out.backgroundColor = style.backgroundColor.trim();
+    // LP CSS の gradient 等を打ち消し、単色背景を反映する
+    out.backgroundImage = "none";
+  }
   return out;
+}
+
+export function normalizeTextFieldStyle(
+  raw: Record<string, unknown>,
+  prev: TextFieldStyle = {},
+): TextFieldStyle {
+  return {
+    fontSize: typeof raw.fontSize === "string" ? raw.fontSize : prev.fontSize,
+    color: typeof raw.color === "string" ? raw.color : prev.color,
+    fontFamily: typeof raw.fontFamily === "string" ? raw.fontFamily : prev.fontFamily,
+    href: typeof raw.href === "string" ? raw.href : prev.href,
+    backgroundColor:
+      typeof raw.backgroundColor === "string" ? raw.backgroundColor : prev.backgroundColor,
+  };
+}
+
+/** JSON 等の raw fieldStyles をマージ（動的キーを保持） */
+export function mergeFieldStylesFromRaw(
+  raw: unknown,
+  base?: HomeCopyFieldStyles,
+): HomeCopyFieldStyles | undefined {
+  if (!raw || typeof raw !== "object") return base;
+  const out: HomeCopyFieldStyles = { ...(base ?? {}) };
+  for (const [id, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (!val || typeof val !== "object") continue;
+    out[id] = normalizeTextFieldStyle(val as Record<string, unknown>, out[id]);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 export function mergeFieldStyles(

--- a/client/src/types/home-copy.ts
+++ b/client/src/types/home-copy.ts
@@ -26,7 +26,7 @@ export interface HomeFaqItem {
   answer: string;
 }
 
-import type { HomeCopyFieldStyles } from "@/types/home-copy-style";
+import { mergeFieldStylesFromRaw, type HomeCopyFieldStyles } from "@/types/home-copy-style";
 
 export interface HomeCopy {
   hero: {
@@ -476,26 +476,6 @@ export function mergeHomeCopy(raw: unknown): HomeCopy {
     },
     fieldStyles: mergeFieldStylesFromRaw(c.fieldStyles, base.fieldStyles),
   };
-}
-
-function mergeFieldStylesFromRaw(
-  raw: unknown,
-  base?: HomeCopy["fieldStyles"],
-): HomeCopyFieldStyles | undefined {
-  if (!raw || typeof raw !== "object") return base;
-  const out: HomeCopyFieldStyles = { ...(base ?? {}) };
-  for (const [id, val] of Object.entries(raw as Record<string, unknown>)) {
-    if (!val || typeof val !== "object") continue;
-    const o = val as Record<string, unknown>;
-    const prev = out[id] ?? {};
-    out[id] = {
-      fontSize: typeof o.fontSize === "string" ? o.fontSize : prev.fontSize,
-      color: typeof o.color === "string" ? o.color : prev.color,
-      fontFamily: typeof o.fontFamily === "string" ? o.fontFamily : prev.fontFamily,
-      href: typeof o.href === "string" ? o.href : prev.href,
-    };
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 export function getStoredHomeCopy(): HomeCopy {

--- a/client/src/types/self-stance.ts
+++ b/client/src/types/self-stance.ts
@@ -1,7 +1,7 @@
 /** /self-stance 専用コンテンツ（ContentPayload.selfStance） */
 
 import seed from "../../public/content/self-stance.json";
-import type { HomeCopyFieldStyles, TextFieldStyle } from "@/types/home-copy-style";
+import { mergeFieldStylesFromRaw, type HomeCopyFieldStyles } from "@/types/home-copy-style";
 
 export const SELF_STANCE_ASSETS = {
   favicon: "/self_stance/favicon.png",
@@ -117,32 +117,12 @@ function mergeDeep(target: Record<string, unknown>, source: Record<string, unkno
  * 新規キー（新たに装飾した要素）を破棄してしまう。そのためここで個別にマージし、
  * 動的キーを保持する（home-copy の mergeFieldStylesFromRaw と同方針）。
  */
-function mergeFieldStyles(
-  raw: unknown,
-  base?: HomeCopyFieldStyles,
-): HomeCopyFieldStyles | undefined {
-  if (!raw || typeof raw !== "object") return base;
-  const out: HomeCopyFieldStyles = { ...(base ?? {}) };
-  for (const [id, val] of Object.entries(raw as Record<string, unknown>)) {
-    if (!val || typeof val !== "object") continue;
-    const o = val as Record<string, unknown>;
-    const prev: TextFieldStyle = out[id] ?? {};
-    out[id] = {
-      fontSize: typeof o.fontSize === "string" ? o.fontSize : prev.fontSize,
-      color: typeof o.color === "string" ? o.color : prev.color,
-      fontFamily: typeof o.fontFamily === "string" ? o.fontFamily : prev.fontFamily,
-      href: typeof o.href === "string" ? o.href : prev.href,
-    };
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
 export function mergeSelfStanceContent(raw: unknown): SelfStanceContent {
   const d = cloneDefault();
   if (!raw || typeof raw !== "object") return d;
   mergeDeep(d as unknown as Record<string, unknown>, raw as Record<string, unknown>);
   // mergeDeep が動的キーを落とすため、fieldStyles は専用ロジックで上書きマージする
-  const merged = mergeFieldStyles(
+  const merged = mergeFieldStylesFromRaw(
     (raw as Record<string, unknown>).fieldStyles,
     d.fieldStyles,
   );


### PR DESCRIPTION
## Summary

- `TextFieldStyle` に `backgroundColor` を追加し、`fieldStyleToCss` 経由で Home / Self-stance に反映
- contents-manager の `TextElementEditor` に背景色 UI（カラーピッカー + hex 入力）を追加
- Self-stance の CTA を `CmId as="a"` に変更し、ボタン全体へ背景色・文字色が適用されるように修正
- `mergeFieldStylesFromRaw` を `home-copy-style.ts` に集約し、home / self-stance の merge 処理を DRY 化

Phase 2（全構造化 LP への横展開）は #19 で追跡。

## Test plan

- [x] `/contents-manager` → self-stance で CTA を選択し、背景色を変更してプレビューに反映される
- [x] 背景色を空にすると LP 既定の CSS に戻る
- [x] Home LP の CTA（`hero-cta` 等）でも背景色が反映される
- [x] 既存のテキスト色・フォント・href 設定が壊れていない
- [x] 保存・リロード後も `fieldStyles.backgroundColor` が保持される


Made with [Cursor](https://cursor.com)