### PR TITLE
feat: Self-stance 固定CTAバーの背景色をカスタマイズ可能に

### DIFF
--- a/client/src/components/contents-manager/FieldStyleEditor.tsx
+++ b/client/src/components/contents-manager/FieldStyleEditor.tsx
@@ -1,0 +1,180 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
+  FONT_FAMILY_OPTIONS,
+  formatFontSizePx,
+  parseFontSizePx,
+  TEXT_SIZE_MAX_PX,
+  TEXT_SIZE_MIN_PX,
+  TEXT_SIZE_SLIDER_DEFAULT_PX,
+  type TextFieldStyle,
+} from "@/types/home-copy-style";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+const fieldCls = "mt-1 border-[#ffd7c3]";
+const labelCls = "text-[#3D281E]";
+
+function ColorField({
+  label,
+  value,
+  placeholder,
+  defaultPickerColor,
+  onChange,
+}: {
+  label: string;
+  value?: string;
+  placeholder: string;
+  defaultPickerColor: string;
+  onChange: (color: string) => void;
+}) {
+  return (
+    <div>
+      <Label className={labelCls}>{label}</Label>
+      <div className="flex gap-2 mt-1">
+        <Input
+          type="color"
+          value={value?.startsWith("#") ? value : defaultPickerColor}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10 w-12 p-1 border-[#ffd7c3] cursor-pointer"
+        />
+        <Input
+          value={value ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={`${fieldCls} flex-1`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TextSizeSlider({
+  fontSize,
+  onFontSizeChange,
+}: {
+  fontSize?: string;
+  onFontSizeChange: (px: number) => void;
+}) {
+  const savedPx = parseFontSizePx(fontSize);
+  const sliderPx = savedPx ?? TEXT_SIZE_SLIDER_DEFAULT_PX;
+  const thumbLabel = savedPx != null ? `${savedPx}px` : `${TEXT_SIZE_SLIDER_DEFAULT_PX}px`;
+
+  return (
+    <div className="mt-2 space-y-1">
+      <SliderPrimitive.Root
+        className="relative flex w-full touch-none items-center select-none py-2"
+        min={TEXT_SIZE_MIN_PX}
+        max={TEXT_SIZE_MAX_PX}
+        step={1}
+        value={[sliderPx]}
+        onValueChange={([v]) => onFontSizeChange(v)}
+        aria-label="テキストサイズ"
+      >
+        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-[#f5e6cd]">
+          <SliderPrimitive.Range className="absolute h-full rounded-full bg-[#d4844b]" />
+        </SliderPrimitive.Track>
+        <SliderPrimitive.Thumb
+          className={cn(
+            "flex h-7 min-w-[3.25rem] shrink-0 items-center justify-center rounded-full border-2 border-[#d4844b] bg-white px-2",
+            "text-xs font-semibold tabular-nums text-[#3D281E] shadow-sm",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d4844b]/40",
+          )}
+        >
+          {thumbLabel}
+        </SliderPrimitive.Thumb>
+      </SliderPrimitive.Root>
+      <div className="flex justify-between text-[10px] text-[#5C3E2A]">
+        <span>{TEXT_SIZE_MIN_PX}px</span>
+        <span>{TEXT_SIZE_MAX_PX}px</span>
+      </div>
+    </div>
+  );
+}
+
+type Props = {
+  style?: TextFieldStyle;
+  onStyleChange: (patch: Partial<TextFieldStyle>) => void;
+  /** レイアウト用コンテナ向け（背景色のみ編集） */
+  containerOnly?: boolean;
+  showHref?: boolean;
+};
+
+export function FieldStyleEditor({
+  style,
+  onStyleChange,
+  containerOnly = false,
+  showHref = true,
+}: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-3 max-w-lg">
+      {!containerOnly && (
+        <div className="col-span-2">
+          <Label className={labelCls}>テキストサイズ</Label>
+          <TextSizeSlider
+            fontSize={style?.fontSize}
+            onFontSizeChange={(px) => onStyleChange({ fontSize: formatFontSizePx(px) })}
+          />
+        </div>
+      )}
+
+      {!containerOnly && (
+        <ColorField
+          label="テキストカラー"
+          value={style?.color}
+          placeholder="#3D281E"
+          defaultPickerColor="#3D281E"
+          onChange={(color) => onStyleChange({ color })}
+        />
+      )}
+
+      <ColorField
+        label="背景色"
+        value={style?.backgroundColor}
+        placeholder="未設定（LP既定）"
+        defaultPickerColor="#3D281E"
+        onChange={(backgroundColor) => onStyleChange({ backgroundColor })}
+      />
+
+      {!containerOnly && (
+        <div>
+          <Label className={labelCls}>テキストフォント</Label>
+          <Select
+            value={style?.fontFamily ?? ""}
+            onValueChange={(v) => onStyleChange({ fontFamily: v === "__default__" ? "" : v })}
+          >
+            <SelectTrigger className={fieldCls}>
+              <SelectValue placeholder="デフォルト" />
+            </SelectTrigger>
+            <SelectContent>
+              {FONT_FAMILY_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value || "__default__"} value={opt.value || "__default__"}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {!containerOnly && showHref && (
+        <div className="col-span-2">
+          <Label className={labelCls}>埋め込みURL</Label>
+          <Input
+            value={style?.href ?? ""}
+            onChange={(e) => onStyleChange({ href: e.target.value })}
+            placeholder="https://..."
+            className={fieldCls}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/contents-manager/LpElementEditor.tsx
+++ b/client/src/components/contents-manager/LpElementEditor.tsx
@@ -1,8 +1,10 @@
 import { DualImageElementEditor } from "@/components/contents-manager/DualImageElementEditor";
+import { FieldStyleEditor } from "@/components/contents-manager/FieldStyleEditor";
 import { LpCopyEditorSections, type WithLpFieldStyles } from "@/components/contents-manager/LpCopyEditorSections";
 import type { LpKind } from "@/lib/content-manager/cm-preview";
 import { findLpField } from "@/lib/content-manager/lp-field-registry";
 import { getFieldPath, setFieldPath } from "@/lib/content-manager/lp-field-path";
+import { patchFieldStyle } from "@/types/home-copy-style";
 
 type Props<T extends WithLpFieldStyles> = {
   kind: LpKind;
@@ -24,6 +26,22 @@ export function LpElementEditor<T extends WithLpFieldStyles>({
   const field = findLpField(slug, sectionId);
   if (!field) {
     return <p className="text-sm text-[#5C3E2A]">この要素のエディタは未設定です。</p>;
+  }
+
+  if (field.kind === "style") {
+    return (
+      <FieldStyleEditor
+        style={content.fieldStyles?.[sectionId]}
+        onStyleChange={(partial) =>
+          onChange((prev) => ({
+            ...prev,
+            fieldStyles: patchFieldStyle(prev.fieldStyles, sectionId, partial),
+          }))
+        }
+        containerOnly={field.containerOnly}
+        showHref={false}
+      />
+    );
   }
 
   if (field.kind === "image") {

--- a/client/src/components/contents-manager/TextElementEditor.tsx
+++ b/client/src/components/contents-manager/TextElementEditor.tsx
@@ -1,61 +1,11 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
-import {
-  FONT_FAMILY_OPTIONS,
-  formatFontSizePx,
-  parseFontSizePx,
-  TEXT_SIZE_MAX_PX,
-  TEXT_SIZE_MIN_PX,
-  TEXT_SIZE_SLIDER_DEFAULT_PX,
-  type TextFieldStyle,
-} from "@/types/home-copy-style";
-import * as SliderPrimitive from "@radix-ui/react-slider";
+import { FieldStyleEditor } from "@/components/contents-manager/FieldStyleEditor";
+import type { TextFieldStyle } from "@/types/home-copy-style";
 
 const fieldCls = "mt-1 border-[#ffd7c3]";
 const labelCls = "text-[#3D281E]";
-
-function ColorField({
-  label,
-  value,
-  placeholder,
-  defaultPickerColor,
-  onChange,
-}: {
-  label: string;
-  value?: string;
-  placeholder: string;
-  defaultPickerColor: string;
-  onChange: (color: string) => void;
-}) {
-  return (
-    <div>
-      <Label className={labelCls}>{label}</Label>
-      <div className="flex gap-2 mt-1">
-        <Input
-          type="color"
-          value={value?.startsWith("#") ? value : defaultPickerColor}
-          onChange={(e) => onChange(e.target.value)}
-          className="h-10 w-12 p-1 border-[#ffd7c3] cursor-pointer"
-        />
-        <Input
-          value={value ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className={`${fieldCls} flex-1`}
-        />
-      </div>
-    </div>
-  );
-}
 
 type Props = {
   text: string;
@@ -65,49 +15,6 @@ type Props = {
   multiline?: boolean;
   rows?: number;
 };
-
-function TextSizeSlider({
-  fontSize,
-  onFontSizeChange,
-}: {
-  fontSize?: string;
-  onFontSizeChange: (px: number) => void;
-}) {
-  const savedPx = parseFontSizePx(fontSize);
-  const sliderPx = savedPx ?? TEXT_SIZE_SLIDER_DEFAULT_PX;
-  const thumbLabel = savedPx != null ? `${savedPx}px` : `${TEXT_SIZE_SLIDER_DEFAULT_PX}px`;
-
-  return (
-    <div className="mt-2 space-y-1">
-      <SliderPrimitive.Root
-        className="relative flex w-full touch-none items-center select-none py-2"
-        min={TEXT_SIZE_MIN_PX}
-        max={TEXT_SIZE_MAX_PX}
-        step={1}
-        value={[sliderPx]}
-        onValueChange={([v]) => onFontSizeChange(v)}
-        aria-label="テキストサイズ"
-      >
-        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-[#f5e6cd]">
-          <SliderPrimitive.Range className="absolute h-full rounded-full bg-[#d4844b]" />
-        </SliderPrimitive.Track>
-        <SliderPrimitive.Thumb
-          className={cn(
-            "flex h-7 min-w-[3.25rem] shrink-0 items-center justify-center rounded-full border-2 border-[#d4844b] bg-white px-2",
-            "text-xs font-semibold tabular-nums text-[#3D281E] shadow-sm",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d4844b]/40",
-          )}
-        >
-          {thumbLabel}
-        </SliderPrimitive.Thumb>
-      </SliderPrimitive.Root>
-      <div className="flex justify-between text-[10px] text-[#5C3E2A]">
-        <span>{TEXT_SIZE_MIN_PX}px</span>
-        <span>{TEXT_SIZE_MAX_PX}px</span>
-      </div>
-    </div>
-  );
-}
 
 export function TextElementEditor({
   text,
@@ -137,60 +44,7 @@ export function TextElementEditor({
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className="col-span-2">
-          <Label className={labelCls}>テキストサイズ</Label>
-          <TextSizeSlider
-            fontSize={style?.fontSize}
-            onFontSizeChange={(px) => onStyleChange({ fontSize: formatFontSizePx(px) })}
-          />
-        </div>
-
-        <ColorField
-          label="テキストカラー"
-          value={style?.color}
-          placeholder="#3D281E"
-          defaultPickerColor="#3D281E"
-          onChange={(color) => onStyleChange({ color })}
-        />
-
-        <ColorField
-          label="背景色"
-          value={style?.backgroundColor}
-          placeholder="未設定（LP既定）"
-          defaultPickerColor="#3D281E"
-          onChange={(backgroundColor) => onStyleChange({ backgroundColor })}
-        />
-
-        <div>
-          <Label className={labelCls}>テキストフォント</Label>
-          <Select
-            value={style?.fontFamily ?? ""}
-            onValueChange={(v) => onStyleChange({ fontFamily: v === "__default__" ? "" : v })}
-          >
-            <SelectTrigger className={fieldCls}>
-              <SelectValue placeholder="デフォルト" />
-            </SelectTrigger>
-            <SelectContent>
-              {FONT_FAMILY_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value || "__default__"} value={opt.value || "__default__"}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="col-span-2">
-          <Label className={labelCls}>埋め込みURL</Label>
-          <Input
-            value={style?.href ?? ""}
-            onChange={(e) => onStyleChange({ href: e.target.value })}
-            placeholder="https://..."
-            className={fieldCls}
-          />
-        </div>
-      </div>
+      <FieldStyleEditor style={style} onStyleChange={onStyleChange} />
     </div>
   );
 }

--- a/client/src/lib/content-manager/generated/btob-lp-fields.ts
+++ b/client/src/lib/content-manager/generated/btob-lp-fields.ts
@@ -2,6 +2,7 @@
 import {
   text,
   image,
+  style,
   indexedFields,
   indexedSimple,
   type LpFieldDef,

--- a/client/src/lib/content-manager/generated/sjh-lp-fields.ts
+++ b/client/src/lib/content-manager/generated/sjh-lp-fields.ts
@@ -2,6 +2,7 @@
 import {
   text,
   image,
+  style,
   indexedFields,
   indexedSimple,
   type LpFieldDef,

--- a/client/src/lib/content-manager/generated/sr-lp-fields.ts
+++ b/client/src/lib/content-manager/generated/sr-lp-fields.ts
@@ -2,6 +2,7 @@
 import {
   text,
   image,
+  style,
   indexedFields,
   indexedSimple,
   type LpFieldDef,

--- a/client/src/lib/content-manager/generated/ss-lp-fields.ts
+++ b/client/src/lib/content-manager/generated/ss-lp-fields.ts
@@ -2,6 +2,7 @@
 import {
   text,
   image,
+  style,
   indexedFields,
   indexedSimple,
   type LpFieldDef,
@@ -11,6 +12,7 @@ export const SS_LP_FIELDS: LpFieldDef[] = [
   image("ss-header-logo", "ヘッダー · ロゴ", "header.logoUrl"),
   text("ss-header-logo-alt", "ヘッダー · ロゴalt", "header.logoAlt"),
   text("ss-header-cta-label", "ヘッダー · CTA", "header.ctaLabel"),
+  style("ss-sticky-cta-bar", "固定CTA · バー", { containerOnly: true }),
   text("ss-sticky-cta-label", "固定CTA · 文言", "stickyCta.label"),
   text("ss-hero-eyebrow", "FV · ラベル", "hero.eyebrow"),
   image("ss-hero-image", "FV · 画像", "hero.heroImageUrl"),

--- a/client/src/lib/content-manager/lp-field-types.ts
+++ b/client/src/lib/content-manager/lp-field-types.ts
@@ -1,7 +1,7 @@
 import type { ElementDefinition } from "@/lib/content-manager/content-element-registry";
 import type { LpKind } from "@/lib/content-manager/cm-preview";
 
-export type LpFieldKind = "text" | "image";
+export type LpFieldKind = "text" | "image" | "style";
 
 export type LpFieldDef = {
   id: string;
@@ -12,6 +12,8 @@ export type LpFieldDef = {
   rows?: number;
   /** 画像フィールドのデフォルトパス */
   imageDefault?: string;
+  /** style フィールド向け: 背景色のみ編集 */
+  containerOnly?: boolean;
 };
 
 export function toElementDefinition(field: LpFieldDef): ElementDefinition {
@@ -31,6 +33,11 @@ export function text(
 
 export function image(id: string, label: string, path: string, imageDefault?: string): LpFieldDef {
   return { id, label, path, kind: "image", imageDefault };
+}
+
+/** テキストなし・装飾のみ編集する要素（固定バー背景など） */
+export function style(id: string, label: string, opts?: { containerOnly?: boolean }): LpFieldDef {
+  return { id, label, path: "", kind: "style", containerOnly: opts?.containerOnly };
 }
 
 export function indexedFields(

--- a/client/src/pages/SelfStance.tsx
+++ b/client/src/pages/SelfStance.tsx
@@ -188,7 +188,7 @@ export default function SelfStance() {
   return (
     <FieldStylesProvider value={c.fieldStyles}>
     <div id="self-stance-page">
-      <div className="sticky">
+      <CmId id="ss-sticky-cta-bar" className="sticky">
         <CmId
           id="ss-sticky-cta-label"
           as="a"
@@ -200,7 +200,7 @@ export default function SelfStance() {
           <LineIcon />
           {c.stickyCta.label}
         </CmId>
-      </div>
+      </CmId>
 
       <header className="site-header">
         <div className="header-inner">

--- a/scripts/generate-lp-fields.mjs
+++ b/scripts/generate-lp-fields.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const outDir = join(__dirname, "../client/src/lib/content-manager/generated");
 
 function emitFile(name, constName, bodyLines) {
-  const content = `/** 自動生成 — scripts/generate-lp-fields.mjs */\nimport {\n  text,\n  image,\n  indexedFields,\n  indexedSimple,\n  type LpFieldDef,\n} from "../lp-field-types";\n\nexport const ${constName}: LpFieldDef[] = [\n${bodyLines.join("\n")}\n];\n`;
+  const content = `/** 自動生成 — scripts/generate-lp-fields.mjs */\nimport {\n  text,\n  image,\n  style,\n  indexedFields,\n  indexedSimple,\n  type LpFieldDef,\n} from "../lp-field-types";\n\nexport const ${constName}: LpFieldDef[] = [\n${bodyLines.join("\n")}\n];\n`;
   writeFileSync(join(outDir, name), content, "utf8");
 }
 
@@ -23,6 +23,12 @@ function t(id, label, path, multiline = false, rows = 4) {
 function img(id, label, path, def) {
   const d = def ? `, "${def}"` : "";
   return `  image("${id}", "${label}", "${path}"${d}),`;
+}
+
+function sty(id, label, containerOnly = false) {
+  return containerOnly
+    ? `  style("${id}", "${label}", { containerOnly: true }),`
+    : `  style("${id}", "${label}"),`;
 }
 
 function idxSimple(prefix, label, count, arrayPath) {
@@ -274,6 +280,7 @@ emitFile("ss-lp-fields.ts", "SS_LP_FIELDS", [
   img("ss-header-logo", "ヘッダー · ロゴ", "header.logoUrl"),
   t("ss-header-logo-alt", "ヘッダー · ロゴalt", "header.logoAlt"),
   t("ss-header-cta-label", "ヘッダー · CTA", "header.ctaLabel"),
+  sty("ss-sticky-cta-bar", "固定CTA · バー", true),
   t("ss-sticky-cta-label", "固定CTA · 文言", "stickyCta.label"),
   t("ss-hero-eyebrow", "FV · ラベル", "hero.eyebrow"),
   img("ss-hero-image", "FV · 画像", "hero.heroImageUrl"),


### PR DESCRIPTION
## Summary

- 固定CTAの外側コンテナ（`.sticky`）に `data-cm-id="ss-sticky-cta-bar"` を付与
- contents-manager で「固定CTA · バー」を選択し、背景色のみ編集できる `style` フィールド種別を追加
- 装飾 UI を `FieldStyleEditor` に抽出し、`TextElementEditor` から再利用

## 使い方

- **バー背景色**: プレビューで固定CTAの余白部分（リンクテキスト以外）をクリック →「固定CTA · バー」
- **文言・文字色**: リンクテキストをクリック →「固定CTA · 文言」

## Test plan

- [ ] `/contents-manager` → self-stance で固定CTAバーの余白をクリックし、背景色が反映される
- [ ] リンクテキスト側の編集（文言・文字色）が従来どおり動作する
- [ ] 背景色を空にすると LP 既定の `--brown-dark` に戻る


Made with [Cursor](https://cursor.com)