### PR TITLE
コンテンツマネージャーに配列項目の追加・削除機能を追加

### DIFF
--- a/client/src/components/contents-manager/ArrayItemEditorPanel.tsx
+++ b/client/src/components/contents-manager/ArrayItemEditorPanel.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ConfirmActionDialog } from "@/components/contents-manager/ConfirmActionDialog";
+import {
+  getArrayItemLabel,
+  type ParsedArrayItem,
+} from "@/lib/content-manager/array-item-registry";
+import type { ArrayMutationOp } from "@/lib/content-manager/array-item-mutations";
+
+type PendingAction = {
+  op: ArrayMutationOp;
+  label: string;
+  title: string;
+  description: string;
+};
+
+type Props = {
+  parsed: ParsedArrayItem;
+  onMutate: (op: ArrayMutationOp) => void;
+  canRemove: boolean;
+  /** standalone: 余白クリック用 / inline: 文言編集パレット下部に併設 */
+  variant?: "standalone" | "inline";
+};
+
+export function ArrayItemEditorPanel({
+  parsed,
+  onMutate,
+  canRemove,
+  variant = "standalone",
+}: Props) {
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const itemLabel = getArrayItemLabel(parsed.def, parsed.index);
+
+  const openConfirm = (op: ArrayMutationOp) => {
+    if (op === "remove") {
+      setPending({
+        op,
+        label: "削除",
+        title: "項目を削除",
+        description: `${itemLabel} を削除してよろしいですか？`,
+      });
+      return;
+    }
+    const position = op === "insertBefore" ? "前" : "後ろ";
+    setPending({
+      op,
+      label: `${position}に追加`,
+      title: `${position}に新しい項目を追加してよろしいですか？`,
+      description: "コピー追加されますので、編集した後保存してください。",
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {variant === "standalone" ? (
+        <p className="text-sm text-[#5C3E2A]">
+          テキスト部分をクリックすると文言の編集パレットが開きます。このパレットでは項目の追加・削除ができます。
+        </p>
+      ) : (
+        <p className="text-sm font-medium text-[#3D281E]">項目の追加・削除</p>
+      )}
+      <div className="flex flex-col gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="border-[#d4844b] text-[#d4844b] justify-center"
+          onClick={() => openConfirm("insertBefore")}
+        >
+          前に追加する
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-[#d4844b] text-[#d4844b] justify-center"
+          onClick={() => openConfirm("insertAfter")}
+        >
+          後ろに追加する
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-red-300 text-red-600 justify-center"
+          disabled={!canRemove}
+          onClick={() => openConfirm("remove")}
+        >
+          項目を削除する
+        </Button>
+        {!canRemove && (
+          <p className="text-xs text-[#5C3E2A]">最低1件は残す必要があります。</p>
+        )}
+      </div>
+
+      {pending && (
+        <ConfirmActionDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setPending(null);
+          }}
+          title={pending.title}
+          description={pending.description}
+          onConfirm={() => onMutate(pending.op)}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/components/contents-manager/CmId.tsx
+++ b/client/src/components/contents-manager/CmId.tsx
@@ -7,6 +7,7 @@ import {
   type ElementType,
   type ReactNode,
 } from "react";
+import { cn } from "@/lib/utils";
 import {
   buildFieldStylesStylesheet,
   fieldStyleToCss,
@@ -140,5 +141,30 @@ export function CmHtml({
       {...(linkHref ? { href: linkHref, ...CM_LINK_PROPS } : {})}
       dangerouslySetInnerHTML={{ __html: html }}
     />
+  );
+}
+
+type CmArrayItemProps = {
+  /** 配列項目 ID（例: values-card-0）。個別フィールドの data-cm-id とは別 */
+  id: string;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+/**
+ * 配列1件分のクリック領域。
+ * 余白部分をクリックすると追加・削除パレットが開き、
+ * 内部の data-cm-id をクリックすると従来どおり文言編集パレットが開く。
+ */
+export function CmArrayItem({ id, className, style, children }: CmArrayItemProps) {
+  return (
+    <div
+      data-cm-array-id={id}
+      className={cn("cm-array-item", className)}
+      style={style}
+    >
+      {children}
+    </div>
   );
 }

--- a/client/src/components/contents-manager/ConfirmActionDialog.tsx
+++ b/client/src/components/contents-manager/ConfirmActionDialog.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+};
+
+/** キャンセル（左）・続ける（右）の確認ダイアログ */
+export function ConfirmActionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "続ける",
+  onConfirm,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogTitle className="text-[#3D281E]">{title}</DialogTitle>
+        <DialogDescription className="text-[#5C3E2A]">{description}</DialogDescription>
+        <div className="flex flex-row items-center justify-between gap-3 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-[#ffd7c3] text-[#5C3E2A]"
+            onClick={() => onOpenChange(false)}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            className="bg-[#d4844b] hover:bg-[#c47540] text-white"
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/contents-manager/EditPaletteSheet.tsx
+++ b/client/src/components/contents-manager/EditPaletteSheet.tsx
@@ -1,4 +1,5 @@
 import { ElementEditorPanel } from "@/components/contents-manager/ElementEditorPanel";
+import { ArrayItemEditorPanel } from "@/components/contents-manager/ArrayItemEditorPanel";
 import { ReadOnlyElementPanel } from "@/components/contents-manager/ReadOnlyElementPanel";
 import {
   Sheet,
@@ -7,6 +8,15 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { findElementDefinition } from "@/lib/content-manager/content-element-registry";
+import {
+  parseArrayItemId,
+  parseCompactArrayItemFromFieldId,
+} from "@/lib/content-manager/array-item-registry";
+import {
+  applyArrayMutation,
+  getArrayLength,
+  type ArrayMutationContext,
+} from "@/lib/content-manager/array-item-ops";
 import { isAutoSelectableId } from "@/lib/content-manager/cm-preview-select";
 import type { HomeElementEditorProps } from "@/components/contents-manager/HomeElementEditor";
 import type { Dispatch, SetStateAction } from "react";
@@ -22,7 +32,9 @@ export interface EditPaletteSheetProps {
   selectedSlug: string;
   elementId: string | null;
   elementLabel?: string | null;
+  selectKind?: "field" | "array" | "auto";
   homeProps: HomeElementEditorProps | null;
+  arrayMutationContext: ArrayMutationContext | null;
   btobSeminarContent: BtobSeminarContent | null;
   onBtobSeminarChange: Dispatch<SetStateAction<BtobSeminarContent | null>>;
   selfReflectionContent: SelfReflectionContent | null;
@@ -41,7 +53,9 @@ export function EditPaletteSheet({
   selectedSlug,
   elementId,
   elementLabel,
+  selectKind,
   homeProps,
+  arrayMutationContext,
   btobSeminarContent,
   onBtobSeminarChange,
   selfReflectionContent,
@@ -53,10 +67,25 @@ export function EditPaletteSheet({
   jsSelfAnalysisContent,
   onJsSelfAnalysisChange,
 }: EditPaletteSheetProps) {
-  const def = elementId ? findElementDefinition(selectedSlug, elementId) : undefined;
+  const arraySelection =
+    elementId && selectKind === "array" && arrayMutationContext
+      ? parseArrayItemId(elementId, selectedSlug)
+      : null;
+  const compactFieldArray =
+    elementId && selectKind === "field" && arrayMutationContext
+      ? parseCompactArrayItemFromFieldId(elementId, selectedSlug)
+      : null;
+  const def =
+    elementId && !arraySelection ? findElementDefinition(selectedSlug, elementId) : undefined;
   const tall = def?.tall ?? false;
-  const title = def?.label ?? elementLabel ?? "要素を編集";
-  const isReadOnly = Boolean(elementId && !def && isAutoSelectableId(elementId));
+  const title =
+    def?.label ??
+    (arraySelection
+      ? `${arraySelection.def.label} ${arraySelection.index + 1}`
+      : null) ??
+    elementLabel ??
+    "要素を編集";
+  const isReadOnly = Boolean(elementId && !def && !arraySelection && isAutoSelectableId(elementId));
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -74,22 +103,47 @@ export function EditPaletteSheet({
             {title}
           </SheetTitle>
         </SheetHeader>
-        {elementId && def && !isReadOnly && (
-          <ElementEditorPanel
-            selectedSlug={selectedSlug}
-            editorSection={def.editorSection}
-            homeProps={homeProps}
-            btobSeminarContent={btobSeminarContent}
-            onBtobSeminarChange={onBtobSeminarChange}
-            selfReflectionContent={selfReflectionContent}
-            onSelfReflectionChange={onSelfReflectionChange}
-            startingJobHuntingContent={startingJobHuntingContent}
-            onStartingJobHuntingChange={onStartingJobHuntingChange}
-            selfStanceContent={selfStanceContent}
-            onSelfStanceChange={onSelfStanceChange}
-            jsSelfAnalysisContent={jsSelfAnalysisContent}
-            onJsSelfAnalysisChange={onJsSelfAnalysisChange}
+        {arraySelection && arrayMutationContext && (
+          <ArrayItemEditorPanel
+            parsed={arraySelection}
+            canRemove={getArrayLength(arrayMutationContext, arraySelection) > (arraySelection.def.minItems ?? 1)}
+            onMutate={(op) => applyArrayMutation(arrayMutationContext, arraySelection, op)}
           />
+        )}
+        {elementId && def && !isReadOnly && !arraySelection && (
+          <div className="space-y-6">
+            <ElementEditorPanel
+              selectedSlug={selectedSlug}
+              editorSection={def.editorSection}
+              homeProps={homeProps}
+              btobSeminarContent={btobSeminarContent}
+              onBtobSeminarChange={onBtobSeminarChange}
+              selfReflectionContent={selfReflectionContent}
+              onSelfReflectionChange={onSelfReflectionChange}
+              startingJobHuntingContent={startingJobHuntingContent}
+              onStartingJobHuntingChange={onStartingJobHuntingChange}
+              selfStanceContent={selfStanceContent}
+              onSelfStanceChange={onSelfStanceChange}
+              jsSelfAnalysisContent={jsSelfAnalysisContent}
+              onJsSelfAnalysisChange={onJsSelfAnalysisChange}
+            />
+            {compactFieldArray && arrayMutationContext && (
+              <>
+                <div className="border-t border-[#ffd7c3]" />
+                <ArrayItemEditorPanel
+                  variant="inline"
+                  parsed={compactFieldArray}
+                  canRemove={
+                    getArrayLength(arrayMutationContext, compactFieldArray) >
+                    (compactFieldArray.def.minItems ?? 1)
+                  }
+                  onMutate={(op) =>
+                    applyArrayMutation(arrayMutationContext, compactFieldArray, op)
+                  }
+                />
+              </>
+            )}
+          </div>
         )}
         {elementId && isReadOnly && <ReadOnlyElementPanel label={title} />}
         </div>

--- a/client/src/components/contents-manager/PreviewSection.tsx
+++ b/client/src/components/contents-manager/PreviewSection.tsx
@@ -15,7 +15,7 @@ const VIEWPORT_WIDTH: Record<Viewport, string> = {
 interface PreviewSectionProps {
   selectedSlug: string;
   payload: ContentPayload;
-  onElementSelect: (id: string, label?: string) => void;
+  onElementSelect: (id: string, label?: string, selectKind?: "field" | "array" | "auto") => void;
 }
 
 export function PreviewSection({ selectedSlug, payload, onElementSelect }: PreviewSectionProps) {
@@ -48,7 +48,7 @@ export function PreviewSection({ selectedSlug, payload, onElementSelect }: Previ
         sendDraft();
       }
       if (event.data.type === "cm-select") {
-        onElementSelect(event.data.id, event.data.label);
+        onElementSelect(event.data.id, event.data.label, event.data.selectKind);
       }
     };
     window.addEventListener("message", handleMessage);
@@ -122,7 +122,7 @@ export function PreviewSection({ selectedSlug, payload, onElementSelect }: Previ
         />
       </div>
       <p className="px-4 py-3 text-xs text-[#5C3E2A] border-t border-[#ffd7c3]">
-        プレビュー上の要素をクリックすると、下から編集パレットが開きます。
+        テキスト部分をクリックすると文言の編集パレットが開きます。項目の余白（点線枠）をクリックすると、追加・削除パレットが開きます。
       </p>
     </div>
   );

--- a/client/src/hooks/useCmPreviewPage.ts
+++ b/client/src/hooks/useCmPreviewPage.ts
@@ -13,6 +13,7 @@ import {
 import {
   CM_PREVIEW_SELECTABLE_SELECTOR,
   getSelectableId,
+  getSelectableKind,
   getSelectableLabel,
   isAccordionToggleTarget,
   openAccordionHostForElement,
@@ -59,6 +60,22 @@ export function useCmPreviewPage({ slug, onDraft, onScrollToId }: Options): bool
         outline-color: #d4844b !important;
         outline-width: 2px !important;
       }
+      [data-cm-array-id] {
+        cursor: pointer !important;
+        outline: 2px dashed transparent;
+        outline-offset: 4px;
+        transition: outline-color 0.15s ease;
+        padding: 6px;
+        margin: 2px 0;
+        box-sizing: border-box;
+      }
+      [data-cm-array-id]:hover {
+        outline-color: rgba(212, 132, 75, 0.45) !important;
+      }
+      [data-cm-array-id][data-cm-active="1"] {
+        outline-color: #d4844b !important;
+        outline-style: dashed !important;
+      }
       [data-faq-toggle], [data-cm-no-select] {
         cursor: pointer !important;
         outline: none !important;
@@ -76,11 +93,12 @@ export function useCmPreviewPage({ slug, onDraft, onScrollToId }: Options): bool
       e.stopPropagation();
       const id = getSelectableId(target);
       const label = getSelectableLabel(target);
+      const selectKind = getSelectableKind(target);
       document.querySelectorAll("[data-cm-active]").forEach((el) => {
         el.removeAttribute("data-cm-active");
       });
       target.setAttribute("data-cm-active", "1");
-      postToCmParent({ type: "cm-select", id, label });
+      postToCmParent({ type: "cm-select", id, label, selectKind });
     };
 
     const handleMessage = (event: MessageEvent) => {
@@ -92,7 +110,9 @@ export function useCmPreviewPage({ slug, onDraft, onScrollToId }: Options): bool
       }
       if (msg.type === "cm-scroll-to") {
         onScrollToIdRef.current?.(msg.id);
-        const el = document.querySelector(`[data-cm-id="${msg.id}"]`);
+        const el =
+          document.querySelector(`[data-cm-id="${msg.id}"]`) ??
+          document.querySelector(`[data-cm-array-id="${msg.id}"]`);
         if (el) {
           openAccordionHostForElement(el);
           el.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/client/src/lib/content-manager/array-item-mutations.ts
+++ b/client/src/lib/content-manager/array-item-mutations.ts
@@ -1,0 +1,75 @@
+import type { ParsedArrayItem } from "@/lib/content-manager/array-item-registry";
+
+function parsePath(path: string): (string | number)[] {
+  const parts: (string | number)[] = [];
+  const re = /([^[\].]+)|\[(\d+)\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(path)) !== null) {
+    if (m[1] != null) parts.push(m[1]);
+    else if (m[2] != null) parts.push(Number(m[2]));
+  }
+  return parts;
+}
+
+function getArrayAtPath(root: unknown, path: string): unknown[] {
+  const parts = parsePath(path);
+  let cur: unknown = root;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== "object") return [];
+    cur = (cur as Record<string | number, unknown>)[p];
+  }
+  return Array.isArray(cur) ? cur : [];
+}
+
+function setArrayAtPath<T extends object>(root: T, path: string, arr: unknown[]): T {
+  const parts = parsePath(path);
+  if (parts.length === 0) return root;
+  const clone = structuredClone(root) as Record<string | number, unknown>;
+  let cur: Record<string | number, unknown> = clone;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    const next = cur[key];
+    if (next == null || typeof next !== "object") {
+      cur[key] = typeof parts[i + 1] === "number" ? [] : {};
+    }
+    cur = cur[key] as Record<string | number, unknown>;
+  }
+  cur[parts[parts.length - 1]] = arr;
+  return clone as T;
+}
+
+export type ArrayMutationOp = "insertBefore" | "insertAfter" | "remove";
+
+export function mutateArrayItem<T extends object>(
+  root: T,
+  storagePath: string,
+  index: number,
+  op: ArrayMutationOp,
+  defaultItem: unknown,
+  minItems = 1,
+): T {
+  const arr = [...getArrayAtPath(root, storagePath)];
+  if (op === "remove") {
+    if (arr.length <= minItems) return root;
+    arr.splice(index, 1);
+    return setArrayAtPath(root, storagePath, arr);
+  }
+  const insertAt = op === "insertBefore" ? index : index + 1;
+  const source = arr[index];
+  const item =
+    source !== undefined
+      ? structuredClone(source)
+      : typeof defaultItem === "function"
+        ? (defaultItem as () => unknown)()
+        : structuredClone(defaultItem);
+  arr.splice(insertAt, 0, item);
+  return setArrayAtPath(root, storagePath, arr);
+}
+
+export function getStoragePath(parsed: ParsedArrayItem): string {
+  return parsed.def.storage.path;
+}
+
+export function readArrayAtPath(root: unknown, path: string): unknown[] {
+  return getArrayAtPath(root, path);
+}

--- a/client/src/lib/content-manager/array-item-ops.ts
+++ b/client/src/lib/content-manager/array-item-ops.ts
@@ -1,0 +1,117 @@
+import type { SelfReflectionContent } from "@/components/SelfReflectionEditor";
+import type { FeatureItem } from "@/lib/content-settings";
+import type { ArrayItemStorage } from "@/lib/content-manager/array-item-registry";
+import {
+  getStoragePath,
+  mutateArrayItem,
+  readArrayAtPath,
+  type ArrayMutationOp,
+} from "@/lib/content-manager/array-item-mutations";
+import type { ParsedArrayItem } from "@/lib/content-manager/array-item-registry";
+import type { BtobSeminarContent } from "@/types/btob-seminar";
+import type { HomeCopy } from "@/types/home-copy";
+import type { JsSelfAnalysisContent } from "@/types/js-self-analysis";
+import type { SelfStanceContent } from "@/types/self-stance";
+import type { StartingJobHuntingContent } from "@/types/starting-job-hunting";
+import { setStoredHomeCopy } from "@/types/home-copy";
+import { setStoredFeatures } from "@/lib/content-settings";
+
+export type ArrayMutationContext = {
+  homeCopy: HomeCopy;
+  onHomeCopyChange: (next: HomeCopy) => void;
+  features: FeatureItem[];
+  onFeaturesChange: (next: FeatureItem[]) => void;
+  btobSeminarContent: BtobSeminarContent | null;
+  onBtobSeminarChange: (next: BtobSeminarContent) => void;
+  selfReflectionContent: SelfReflectionContent | null;
+  onSelfReflectionChange: (next: SelfReflectionContent) => void;
+  startingJobHuntingContent: StartingJobHuntingContent | null;
+  onStartingJobHuntingChange: (next: StartingJobHuntingContent) => void;
+  selfStanceContent: SelfStanceContent | null;
+  onSelfStanceChange: (next: SelfStanceContent) => void;
+  jsSelfAnalysisContent: JsSelfAnalysisContent | null;
+  onJsSelfAnalysisChange: (next: JsSelfAnalysisContent) => void;
+};
+
+function resolveRoot(ctx: ArrayMutationContext, storage: ArrayItemStorage): unknown {
+  switch (storage.bucket) {
+    case "homeCopy":
+      return ctx.homeCopy;
+    case "features":
+      return { items: ctx.features };
+    case "btobSeminar":
+      return ctx.btobSeminarContent;
+    case "selfReflection":
+      return ctx.selfReflectionContent;
+    case "startingJobHunting":
+      return ctx.startingJobHuntingContent;
+    case "selfStance":
+      return ctx.selfStanceContent;
+    case "jsSelfAnalysis":
+      return ctx.jsSelfAnalysisContent;
+    default:
+      return null;
+  }
+}
+
+export function getArrayLength(ctx: ArrayMutationContext, parsed: ParsedArrayItem): number {
+  const root = resolveRoot(ctx, parsed.def.storage);
+  if (!root) return 0;
+  const path = parsed.def.storage.bucket === "features" ? "items" : parsed.def.storage.path;
+  return readArrayAtPath(root, path).length;
+}
+
+export function applyArrayMutation(
+  ctx: ArrayMutationContext,
+  parsed: ParsedArrayItem,
+  op: ArrayMutationOp,
+): void {
+  const { def } = parsed;
+  const minItems = def.minItems ?? 1;
+  const defaultItem = def.createDefault();
+  const isFeatures = def.storage.bucket === "features";
+  const path = isFeatures ? "items" : def.storage.path;
+  const root = resolveRoot(ctx, def.storage);
+  if (!root || typeof root !== "object") return;
+
+  const next = mutateArrayItem(
+    root as object,
+    path,
+    parsed.index,
+    op,
+    defaultItem,
+    minItems,
+  );
+
+  switch (def.storage.bucket) {
+    case "homeCopy":
+      ctx.onHomeCopyChange(next as HomeCopy);
+      setStoredHomeCopy(next as HomeCopy);
+      break;
+    case "features": {
+      const items = readArrayAtPath(next, "items") as FeatureItem[];
+      ctx.onFeaturesChange(items);
+      setStoredFeatures(items);
+      break;
+    }
+    case "btobSeminar":
+      ctx.onBtobSeminarChange(next as BtobSeminarContent);
+      break;
+    case "selfReflection":
+      ctx.onSelfReflectionChange(next as SelfReflectionContent);
+      break;
+    case "startingJobHunting":
+      ctx.onStartingJobHuntingChange(next as StartingJobHuntingContent);
+      break;
+    case "selfStance":
+      ctx.onSelfStanceChange(next as SelfStanceContent);
+      break;
+    case "jsSelfAnalysis":
+      ctx.onJsSelfAnalysisChange(next as JsSelfAnalysisContent);
+      break;
+    default:
+      break;
+  }
+}
+
+export { getStoragePath };

--- a/client/src/lib/content-manager/array-item-registry.ts
+++ b/client/src/lib/content-manager/array-item-registry.ts
@@ -1,0 +1,484 @@
+import { getLpKind, type LpKind } from "@/lib/content-manager/cm-preview";
+import type { ElementDefinition } from "@/lib/content-manager/content-element-registry";
+
+/** 配列1件分のフィールド定義（オブジェクト型配列） */
+export type ArrayObjectField = {
+  suffix: string;
+  label: string;
+  multiline?: boolean;
+  rows?: number;
+};
+
+export type ArrayItemStorage =
+  | { bucket: "homeCopy"; path: string }
+  | { bucket: "features" }
+  | { bucket: "btobSeminar"; path: string }
+  | { bucket: "selfReflection"; path: string }
+  | { bucket: "startingJobHunting"; path: string }
+  | { bucket: "selfStance"; path: string }
+  | { bucket: "jsSelfAnalysis"; path: string };
+
+export type ArrayItemDefinition = {
+  prefix: string;
+  label: string;
+  storage: ArrayItemStorage;
+  /** string = 文字列配列, object = オブジェクト配列 */
+  itemKind: "string" | "object";
+  fields?: ArrayObjectField[];
+  createDefault: () => unknown;
+  minItems?: number;
+};
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ─── Home LP ───
+const HOME_ARRAYS: ArrayItemDefinition[] = [
+  {
+    prefix: "values-card",
+    label: "Values",
+    storage: { bucket: "homeCopy", path: "values.items" },
+    itemKind: "object",
+    fields: [
+      { suffix: "label", label: "ラベル" },
+      { suffix: "title", label: "見出し" },
+      { suffix: "body", label: "本文", multiline: true, rows: 4 },
+      { suffix: "note", label: "補足", multiline: true, rows: 3 },
+    ],
+    createDefault: () => ({ label: "", title: "", body: "", note: "" }),
+  },
+  {
+    prefix: "event-flow-step",
+    label: "フロー",
+    storage: { bucket: "homeCopy", path: "eventFlow.steps" },
+    itemKind: "object",
+    fields: [
+      { suffix: "title", label: "タイトル" },
+      { suffix: "time", label: "時間" },
+      { suffix: "description", label: "説明", multiline: true, rows: 3 },
+    ],
+    createDefault: () => ({ title: "", time: "", description: "" }),
+  },
+  {
+    prefix: "feature",
+    label: "特徴",
+    storage: { bucket: "features" },
+    itemKind: "object",
+    fields: [
+      { suffix: "title", label: "見出し" },
+      { suffix: "body", label: "本文", multiline: true, rows: 4 },
+    ],
+    createDefault: () => ({ title: "", body: "", imageUrl: null }),
+  },
+  {
+    prefix: "voices-card",
+    label: "声",
+    storage: { bucket: "homeCopy", path: "voices.items" },
+    itemKind: "object",
+    fields: [
+      { suffix: "quote", label: "引用", multiline: true, rows: 4 },
+      { suffix: "attribution", label: "属性" },
+    ],
+    createDefault: () => ({ quote: "", attribution: "" }),
+  },
+  {
+    prefix: "screening-criterion",
+    label: "Screening 基準",
+    storage: { bucket: "homeCopy", path: "screening.criteria" },
+    itemKind: "string",
+    createDefault: () => "",
+  },
+  {
+    prefix: "safety-item",
+    label: "安全",
+    storage: { bucket: "homeCopy", path: "safety.items" },
+    itemKind: "object",
+    fields: [
+      { suffix: "title", label: "タイトル" },
+      { suffix: "description", label: "説明", multiline: true, rows: 3 },
+    ],
+    createDefault: () => ({ title: "", description: "" }),
+  },
+  {
+    prefix: "faq-item",
+    label: "FAQ",
+    storage: { bucket: "homeCopy", path: "faq.items" },
+    itemKind: "object",
+    fields: [
+      { suffix: "question", label: "質問" },
+      { suffix: "answer", label: "回答", multiline: true, rows: 4 },
+    ],
+    createDefault: () => ({ question: "", answer: "" }),
+  },
+];
+
+function objDef(
+  prefix: string,
+  label: string,
+  bucket: ArrayItemStorage["bucket"],
+  path: string,
+  fields: ArrayObjectField[],
+  createDefault: () => unknown,
+): ArrayItemDefinition {
+  const storage =
+    bucket === "homeCopy"
+      ? { bucket, path }
+      : bucket === "btobSeminar"
+        ? { bucket, path }
+        : bucket === "selfReflection"
+          ? { bucket, path }
+          : bucket === "startingJobHunting"
+            ? { bucket, path }
+            : bucket === "selfStance"
+              ? { bucket, path }
+              : { bucket, path };
+  return { prefix, label, storage, itemKind: "object", fields, createDefault };
+}
+
+function strDef(
+  prefix: string,
+  label: string,
+  bucket: ArrayItemStorage["bucket"],
+  path: string,
+): ArrayItemDefinition {
+  const storage =
+    bucket === "homeCopy"
+      ? { bucket, path }
+      : bucket === "btobSeminar"
+        ? { bucket, path }
+        : bucket === "selfReflection"
+          ? { bucket, path }
+          : bucket === "startingJobHunting"
+            ? { bucket, path }
+            : bucket === "selfStance"
+              ? { bucket, path }
+              : { bucket, path };
+  return { prefix, label, storage, itemKind: "string", createDefault: () => "" };
+}
+
+// ─── BTOB ───
+const BTOB_ARRAYS: ArrayItemDefinition[] = [
+  objDef("btob-hero-info", "ヒーロー情報", "btobSeminar", "hero.info", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+  ], () => ({ label: "", value: "" })),
+  strDef("btob-empathy-checklist", "共感 · チェック", "btobSeminar", "empathy.checklist"),
+  objDef("btob-structure-step", "ループ", "btobSeminar", "structure.steps", [
+    { suffix: "num", label: "番号" },
+    { suffix: "label", label: "ラベル" },
+    { suffix: "desc", label: "説明" },
+  ], () => ({ num: "", label: "", desc: "" })),
+  objDef("btob-experience-item", "体験", "btobSeminar", "experience.items", [
+    { suffix: "num", label: "番号" },
+    { suffix: "name", label: "名前" },
+    { suffix: "descHtml", label: "説明", multiline: true, rows: 4 },
+  ], () => ({ num: "", name: "", descHtml: "" })),
+  objDef("btob-takeaway-card", "持ち帰り", "btobSeminar", "takeaway.cards", [
+    { suffix: "icon", label: "アイコン" },
+    { suffix: "titleHtml", label: "タイトル", multiline: true, rows: 2 },
+    { suffix: "desc", label: "説明", multiline: true, rows: 3 },
+  ], () => ({ icon: "", titleHtml: "", desc: "" })),
+  strDef("btob-audience-item", "対象者", "btobSeminar", "audience.items"),
+  objDef("btob-hosts-card", "主催", "btobSeminar", "hosts.cards", [
+    { suffix: "role", label: "役割" },
+    { suffix: "roleJp", label: "役割（日）" },
+    { suffix: "name", label: "名前" },
+    { suffix: "desc", label: "説明", multiline: true, rows: 3 },
+  ], () => ({ role: "", roleJp: "", name: "", desc: "" })),
+  objDef("btob-details-row", "概要", "btobSeminar", "details.rows", [
+    { suffix: "th", label: "項目" },
+    { suffix: "tdHtml", label: "内容", multiline: true, rows: 3 },
+  ], () => ({ th: "", tdHtml: "" })),
+  objDef("btob-faq-item", "FAQ", "btobSeminar", "faq.items", [
+    { suffix: "q", label: "質問" },
+    { suffix: "a", label: "回答", multiline: true, rows: 4 },
+  ], () => ({ q: "", a: "" })),
+];
+
+// ─── Self Reflection ───
+const SR_ARRAYS: ArrayItemDefinition[] = [
+  strDef("sr-event-info-tag", "イベント · タグ", "selfReflection", "eventInfo.tags"),
+  strDef("sr-issue-item", "課題", "selfReflection", "issue.items"),
+  strDef("sr-concept-tag", "コンセプト · タグ", "selfReflection", "concept.tagsHtml"),
+  objDef("sr-steps-item", "ステップ", "selfReflection", "steps.items", [
+    { suffix: "num", label: "番号" },
+    { suffix: "min", label: "時間" },
+    { suffix: "title", label: "タイトル" },
+    { suffix: "tagline", label: "タグライン" },
+    { suffix: "desc", label: "説明", multiline: true, rows: 4 },
+  ], () => ({ num: "", min: "", title: "", tagline: "", desc: "" })),
+  objDef("sr-voices-card", "体験者", "selfReflection", "voices.cards", [
+    { suffix: "change", label: "変化", multiline: true, rows: 2 },
+    { suffix: "quote", label: "引用", multiline: true, rows: 4 },
+  ], () => ({ change: "", quote: "" })),
+  objDef("sr-safety-item", "安心", "selfReflection", "safety.items", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "desc", label: "説明", multiline: true, rows: 3 },
+  ], () => ({ label: "", desc: "" })),
+  strDef("sr-advisor-bio", "アドバイザー · 経歴", "selfReflection", "advisor.bio"),
+  objDef("sr-faq-item", "FAQ", "selfReflection", "faq.items", [
+    { suffix: "q", label: "質問" },
+    { suffix: "a", label: "回答", multiline: true, rows: 4 },
+  ], () => ({ q: "", a: "" })),
+];
+
+// ─── Starting Job Hunting ───
+const SJH_ARRAYS: ArrayItemDefinition[] = [
+  objDef("sjh-event-info-row", "イベント", "startingJobHunting", "eventInfo.rows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+    { suffix: "sub", label: "補足" },
+  ], () => ({ label: "", value: "", sub: "" })),
+  strDef("sjh-problem-item", "Problem", "startingJobHunting", "problem.items"),
+  strDef("sjh-insight-paragraph", "Insight", "startingJobHunting", "insight.paragraphs"),
+  objDef("sjh-solution-deliverable", "Solution", "startingJobHunting", "solution.deliverables", [
+    { suffix: "num", label: "番号" },
+    { suffix: "text", label: "内容", multiline: true, rows: 3 },
+  ], () => ({ num: "", text: "" })),
+  objDef("sjh-program-row", "Program", "startingJobHunting", "program.rows", [
+    { suffix: "step", label: "ステップ" },
+    { suffix: "content", label: "内容", multiline: true, rows: 3 },
+  ], () => ({ step: "", content: "" })),
+  strDef("sjh-program-point", "Program · ポイント", "startingJobHunting", "program.points"),
+  strDef("sjh-facilitator-bio", "Facilitator · 経歴", "startingJobHunting", "facilitator.bio"),
+  objDef("sjh-voices-item", "参加者の声", "startingJobHunting", "voices.items", [
+    { suffix: "school", label: "学校" },
+    { suffix: "comment", label: "コメント", multiline: true, rows: 4 },
+  ], () => ({ school: "", comment: "" })),
+  objDef("sjh-info-row", "開催情報", "startingJobHunting", "info.scheduleRows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+    { suffix: "sub", label: "補足" },
+  ], () => ({ label: "", value: "", sub: "" })),
+  strDef("sjh-recommend-item", "おすすめ", "startingJobHunting", "recommend.items"),
+  objDef("sjh-faq-item", "FAQ", "startingJobHunting", "faq.items", [
+    { suffix: "q", label: "質問" },
+    { suffix: "a", label: "回答", multiline: true, rows: 4 },
+  ], () => ({ q: "", a: "" })),
+  strDef("sjh-final-cta-meta", "最終CTA · メタ", "startingJobHunting", "finalCta.metaItems"),
+  strDef("sjh-footer-line", "フッター", "startingJobHunting", "footer.lines"),
+];
+
+// ─── Self Stance ───
+const SS_ARRAYS: ArrayItemDefinition[] = [
+  objDef("ss-event-info-row", "イベント", "selfStance", "eventInfo.rows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+  ], () => ({ label: "", value: "" })),
+  strDef("ss-problem-item", "悩み", "selfStance", "empathy.items"),
+  strDef("ss-solution-benefit", "メリット", "selfStance", "solution.benefits"),
+  objDef("ss-program-step", "Program", "selfStance", "program.steps", [
+    { suffix: "num", label: "番号" },
+    { suffix: "nameHtml", label: "名前", multiline: true, rows: 2 },
+    { suffix: "description", label: "説明", multiline: true, rows: 3 },
+  ], () => ({ num: "", nameHtml: "", description: "" })),
+  strDef("ss-program-point", "Program · ポイント", "selfStance", "program.points"),
+  strDef("ss-facilitator-bio", "Facilitator · 経歴", "selfStance", "facilitator.bio"),
+  objDef("ss-voices-item", "参加者の声", "selfStance", "voices.items", [
+    { suffix: "who", label: "属性" },
+    { suffix: "text", label: "コメント", multiline: true, rows: 4 },
+  ], () => ({ who: "", text: "" })),
+  objDef("ss-detail-row", "開催情報", "selfStance", "detail.scheduleRows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+  ], () => ({ label: "", value: "" })),
+  strDef("ss-target-item", "おすすめ", "selfStance", "target.items"),
+  objDef("ss-faq-item", "FAQ", "selfStance", "faq.items", [
+    { suffix: "q", label: "質問" },
+    { suffix: "a", label: "回答", multiline: true, rows: 4 },
+  ], () => ({ q: "", a: "" })),
+  strDef("ss-final-cta-paragraph", "最終CTA", "selfStance", "finalCta.paragraphs"),
+  strDef("ss-footer-line", "フッター", "selfStance", "footer.lines"),
+];
+
+// ─── JS Self Analysis ───
+const JSA_ARRAYS: ArrayItemDefinition[] = [
+  objDef("jsa-hero-info-row", "FV情報", "jsSelfAnalysis", "hero.infoRows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+  ], () => ({ label: "", value: "" })),
+  strDef("jsa-empathy-item", "共感", "jsSelfAnalysis", "empathy.items"),
+  strDef("jsa-solution-outcome", "得られるもの", "jsSelfAnalysis", "solution.outcomes"),
+  objDef("jsa-schedule-step", "ワーク", "jsSelfAnalysis", "schedule.steps", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "title", label: "タイトル" },
+    { suffix: "desc", label: "説明", multiline: true, rows: 3 },
+  ], () => ({ label: "", title: "", desc: "" })),
+  strDef("jsa-schedule-note", "当日の流れ · 注記", "jsSelfAnalysis", "schedule.notes"),
+  strDef("jsa-facilitator-bio", "Facilitator · 経歴", "jsSelfAnalysis", "facilitator.bio"),
+  objDef("jsa-voices-item", "参加者の声", "jsSelfAnalysis", "voices.items", [
+    { suffix: "who", label: "属性" },
+    { suffix: "text", label: "コメント", multiline: true, rows: 4 },
+  ], () => ({ who: "", text: "" })),
+  objDef("jsa-event-info-row", "開催情報", "jsSelfAnalysis", "eventInfo.rows", [
+    { suffix: "label", label: "ラベル" },
+    { suffix: "value", label: "値" },
+  ], () => ({ label: "", value: "" })),
+  strDef("jsa-forwho-item", "おすすめ", "jsSelfAnalysis", "forWho.items"),
+  objDef("jsa-faq-item", "FAQ", "jsSelfAnalysis", "faq.items", [
+    { suffix: "q", label: "質問" },
+    { suffix: "a", label: "回答", multiline: true, rows: 4 },
+  ], () => ({ q: "", a: "" })),
+];
+
+const ARRAYS_BY_KIND: Record<LpKind, ArrayItemDefinition[]> = {
+  home: HOME_ARRAYS,
+  btob_seminar: BTOB_ARRAYS,
+  self_reflection: SR_ARRAYS,
+  starting_job_hunting: SJH_ARRAYS,
+  self_stance: SS_ARRAYS,
+  js_self_analysis: JSA_ARRAYS,
+};
+
+/** prefix 長い順（より具体的なマッチを優先） */
+function sortedDefs(slug: string): ArrayItemDefinition[] {
+  return [...(ARRAYS_BY_KIND[getLpKind(slug)] ?? [])].sort(
+    (a, b) => b.prefix.length - a.prefix.length,
+  );
+}
+
+export type ParsedArrayItem = {
+  def: ArrayItemDefinition;
+  index: number;
+  id: string;
+};
+
+/** `values-card-0` 形式の配列項目 ID を解析 */
+export function parseArrayItemId(id: string, slug: string): ParsedArrayItem | null {
+  for (const def of sortedDefs(slug)) {
+    const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)$`);
+    const m = id.match(re);
+    if (!m) continue;
+    const index = parseInt(m[1], 10);
+    if (Number.isNaN(index) || index < 0) return null;
+    return { def, index, id };
+  }
+  return null;
+}
+
+/**
+ * 表形式・リスト形式など余白クリックが難しい配列。
+ * 文言フィールド選択時に編集パレットへ行操作を併設する。
+ */
+export const COMPACT_ARRAY_ITEM_PREFIXES = new Set([
+  "btob-empathy-checklist",
+  "btob-audience-item",
+  "btob-details-row",
+  "sr-event-info-tag",
+  "sr-concept-tag",
+  "sjh-program-row",
+  "sjh-info-row",
+  "ss-program-step",
+  "ss-detail-row",
+  "ss-final-cta-paragraph",
+]);
+
+export function isCompactArrayItemPrefix(prefix: string): boolean {
+  return COMPACT_ARRAY_ITEM_PREFIXES.has(prefix);
+}
+
+/** コンパクト配列のフィールド ID から所属項目を特定（該当しない場合は null） */
+export function parseCompactArrayItemFromFieldId(
+  id: string,
+  slug: string,
+): ParsedArrayItem | null {
+  const parsed = parseArrayItemFromFieldId(id, slug);
+  if (!parsed || !isCompactArrayItemPrefix(parsed.def.prefix)) return null;
+  return parsed;
+}
+
+export function parseArrayItemFromFieldId(id: string, slug: string): ParsedArrayItem | null {
+  for (const def of sortedDefs(slug)) {
+    if (def.itemKind === "string") {
+      const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)$`);
+      const m = id.match(re);
+      if (m) {
+        const index = parseInt(m[1], 10);
+        if (!Number.isNaN(index) && index >= 0) return { def, index, id: m[0] };
+      }
+      continue;
+    }
+    for (const f of def.fields ?? []) {
+      const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)-${escapeRegex(f.suffix)}$`);
+      const m = id.match(re);
+      if (m) {
+        const index = parseInt(m[1], 10);
+        if (!Number.isNaN(index) && index >= 0) {
+          return { def, index, id: `${def.prefix}-${index}` };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function getArrayItemLabel(def: ArrayItemDefinition, index: number): string {
+  return `${def.label} ${index + 1}`;
+}
+
+export function getArrayDefsForKind(kind: LpKind): ArrayItemDefinition[] {
+  return ARRAYS_BY_KIND[kind] ?? [];
+}
+
+/** 動的インデックスのフィールド定義（LpFieldDef 互換） */
+export function buildDynamicFieldDef(
+  id: string,
+  slug: string,
+): { id: string; label: string; path: string; multiline?: boolean; rows?: number } | null {
+  for (const def of sortedDefs(slug)) {
+    if (def.itemKind === "string") continue;
+    for (const f of def.fields ?? []) {
+      const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)-${escapeRegex(f.suffix)}$`);
+      const m = id.match(re);
+      if (!m) continue;
+      const index = parseInt(m[1], 10);
+      if (Number.isNaN(index) || index < 0) return null;
+      return {
+        id,
+        label: `${def.label} ${index + 1} · ${f.label}`,
+        path: `${def.storage.path}[${index}].${f.suffix}`,
+        multiline: f.multiline,
+        rows: f.rows,
+      };
+    }
+  }
+  for (const def of sortedDefs(slug)) {
+    if (def.itemKind !== "string") continue;
+    const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)$`);
+    const m = id.match(re);
+    if (!m) continue;
+    const index = parseInt(m[1], 10);
+    if (Number.isNaN(index) || index < 0) return null;
+    return {
+      id,
+      label: `${def.label} ${index + 1}`,
+      path: `${def.storage.path}[${index}]`,
+    };
+  }
+  return null;
+}
+
+/** Home LP 向け動的 ElementDefinition */
+export function buildHomeDynamicElementDef(id: string): ElementDefinition | null {
+  for (const def of HOME_ARRAYS) {
+    if (def.itemKind === "string") {
+      const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)$`);
+      const m = id.match(re);
+      if (m) {
+        const index = parseInt(m[1], 10);
+        return { id, label: `${def.label} ${index + 1}`, editorSection: id };
+      }
+      continue;
+    }
+    for (const f of def.fields ?? []) {
+      const re = new RegExp(`^${escapeRegex(def.prefix)}-(\\d+)-${escapeRegex(f.suffix)}$`);
+      const m = id.match(re);
+      if (m) {
+        const index = parseInt(m[1], 10);
+        return { id, label: `${def.label} ${index + 1} · ${f.label}`, editorSection: id };
+      }
+    }
+  }
+  return null;
+}

--- a/client/src/lib/content-manager/cm-preview-select.ts
+++ b/client/src/lib/content-manager/cm-preview-select.ts
@@ -90,16 +90,23 @@ export function resolveClickTarget(raw: EventTarget | null): HTMLElement | null 
   let start: Element | null = raw;
   if (start instanceof SVGElement || start.closest(SKIP_ANCESTOR_SELECTOR) === start) {
     start =
-      start.closest("button, a[href], [data-cm-id], summary, label") ??
+      start.closest("button, a[href], [data-cm-id], [data-cm-array-id], summary, label") ??
       start.parentElement;
   }
 
   if (!(start instanceof HTMLElement)) return null;
 
-  // 登録済み [data-cm-id] を最優先（セクション単位の編集パレットを開く）
+  // 文言フィールド（data-cm-id）を最優先
   let el: HTMLElement | null = start;
   while (el && el !== document.documentElement) {
     if (el.hasAttribute("data-cm-id")) return el;
+    el = el.parentElement;
+  }
+
+  // 配列項目全体（data-cm-array-id）
+  el = start;
+  while (el && el !== document.documentElement) {
+    if (el.hasAttribute("data-cm-array-id")) return el;
     el = el.parentElement;
   }
 
@@ -113,13 +120,25 @@ export function resolveClickTarget(raw: EventTarget | null): HTMLElement | null 
   return null;
 }
 
+export function getSelectableKind(el: HTMLElement): "field" | "array" | "auto" {
+  if (el.hasAttribute("data-cm-array-id")) return "array";
+  if (el.hasAttribute("data-cm-id")) return "field";
+  return "auto";
+}
+
 export function getSelectableId(el: HTMLElement): string {
+  if (el.hasAttribute("data-cm-array-id")) {
+    return el.getAttribute("data-cm-array-id")!;
+  }
   const cmId = el.getAttribute("data-cm-id");
   if (cmId) return cmId;
   return `auto:${buildElementPath(el)}`;
 }
 
 export function getSelectableLabel(el: HTMLElement): string {
+  const arrayLabel = el.getAttribute("data-cm-array-label");
+  if (arrayLabel?.trim()) return arrayLabel.trim();
+
   const explicit = el.getAttribute("data-cm-label");
   if (explicit?.trim()) return explicit.trim();
 

--- a/client/src/lib/content-manager/cm-preview.ts
+++ b/client/src/lib/content-manager/cm-preview.ts
@@ -56,7 +56,7 @@ export function isCmPreviewMode(search?: string): boolean {
 
 export type CmPreviewMessage =
   | { type: "cm-ready" }
-  | { type: "cm-select"; id: string; label?: string }
+  | { type: "cm-select"; id: string; label?: string; selectKind?: "field" | "array" | "auto" }
   | { type: "cm-draft"; slug: string; payload: ContentPayload }
   | { type: "cm-scroll-to"; id: string };
 

--- a/client/src/lib/content-manager/content-element-registry.ts
+++ b/client/src/lib/content-manager/content-element-registry.ts
@@ -1,6 +1,10 @@
 import { getLpKind, type LpKind } from "@/lib/content-manager/cm-preview";
+import {
+  buildHomeDynamicElementDef,
+  parseArrayItemId,
+} from "@/lib/content-manager/array-item-registry";
 import { HOME_COPY_ELEMENTS } from "@/lib/content-manager/home-copy-elements";
-import { getLpFieldElements, findLpField } from "@/lib/content-manager/lp-field-registry";
+import { getLpFieldElements, findLpField, findArrayItemElementDefinition } from "@/lib/content-manager/lp-field-registry";
 
 export type ElementDefinition = {
   id: string;
@@ -32,8 +36,18 @@ export function getElementRegistry(slug: string): ElementDefinition[] {
 }
 
 export function findElementDefinition(slug: string, id: string): ElementDefinition | undefined {
+  const arrayDef = findArrayItemElementDefinition(slug, id);
+  if (arrayDef) return arrayDef;
+
   const exact = getElementRegistry(slug).find((el) => el.id === id);
   if (exact) return exact;
+
+  if (getLpKind(slug) === "home") {
+    const homeDynamic = buildHomeDynamicElementDef(id);
+    if (homeDynamic) return homeDynamic;
+    return undefined;
+  }
+
   const lpField = findLpField(slug, id);
   if (lpField) {
     return { id: lpField.id, label: lpField.label, editorSection: lpField.id };

--- a/client/src/lib/content-manager/home-copy-elements.ts
+++ b/client/src/lib/content-manager/home-copy-elements.ts
@@ -49,7 +49,6 @@ function indexedSimple(prefix: string, labelPrefix: string, count: number): Elem
 
 
 /** Home LP の文言・画像要素（プレビュー個別選択用） */
-
 export const HOME_COPY_ELEMENTS: ElementDefinition[] = [
 
   def("brand-logo", "ブランドロゴ"),
@@ -217,6 +216,8 @@ const HOME_COPY_FIELD_PATTERNS: RegExp[] = [
   /^values-card-\d+-(label|title|body|note)$/,
 
   /^event-flow-step-\d+-(title|time|description)$/,
+
+  /^feature-\d+-(title|body|image)$/,
 
   /^voices-card-\d+-(quote|attribution)$/,
 

--- a/client/src/lib/content-manager/lp-field-registry.ts
+++ b/client/src/lib/content-manager/lp-field-registry.ts
@@ -1,5 +1,11 @@
 import { getLpKind, type LpKind } from "@/lib/content-manager/cm-preview";
 import type { ElementDefinition } from "@/lib/content-manager/content-element-registry";
+import {
+  buildDynamicFieldDef,
+  buildHomeDynamicElementDef,
+  getArrayItemLabel,
+  parseArrayItemId,
+} from "@/lib/content-manager/array-item-registry";
 import { BTOB_LP_FIELDS } from "@/lib/content-manager/generated/btob-lp-fields";
 import { SJH_LP_FIELDS } from "@/lib/content-manager/generated/sjh-lp-fields";
 import { SR_LP_FIELDS } from "@/lib/content-manager/generated/sr-lp-fields";
@@ -22,90 +28,14 @@ const FIELD_MAP_BY_KIND = Object.fromEntries(
   ]),
 ) as Record<Exclude<LpKind, "home">, Map<string, LpFieldDef>>;
 
-/** 動的インデックス（FAQ 追加行など）向けフォールバック */
-const DYNAMIC_FIELD_PATTERNS: Partial<
-  Record<Exclude<LpKind, "home">, { re: RegExp; build: (m: RegExpMatchArray) => LpFieldDef | null }[]>
-> = {
-  btob_seminar: [
-    {
-      re: /^btob-faq-item-(\d+)-(q|a)$/,
-      build: (m) => ({
-        id: m[0],
-        label: `FAQ ${Number(m[1]) + 1} · ${m[2] === "q" ? "質問" : "回答"}`,
-        path: `faq.items[${m[1]}].${m[2]}`,
-        kind: "text",
-        multiline: m[2] === "a",
-        rows: m[2] === "a" ? 4 : undefined,
-      }),
-    },
-  ],
-  self_reflection: [
-    {
-      re: /^sr-faq-item-(\d+)-(q|a)$/,
-      build: (m) => ({
-        id: m[0],
-        label: `FAQ ${Number(m[1]) + 1} · ${m[2] === "q" ? "質問" : "回答"}`,
-        path: `faq.items[${m[1]}].${m[2]}`,
-        kind: "text",
-        multiline: m[2] === "a",
-        rows: m[2] === "a" ? 4 : undefined,
-      }),
-    },
-  ],
-  starting_job_hunting: [
-    {
-      re: /^sjh-faq-item-(\d+)-(q|a)$/,
-      build: (m) => ({
-        id: m[0],
-        label: `FAQ ${Number(m[1]) + 1} · ${m[2] === "q" ? "質問" : "回答"}`,
-        path: `faq.items[${m[1]}].${m[2]}`,
-        kind: "text",
-        multiline: m[2] === "a",
-        rows: m[2] === "a" ? 4 : undefined,
-      }),
-    },
-  ],
-  self_stance: [
-    {
-      re: /^ss-faq-item-(\d+)-(q|a)$/,
-      build: (m) => ({
-        id: m[0],
-        label: `FAQ ${Number(m[1]) + 1} · ${m[2] === "q" ? "質問" : "回答"}`,
-        path: `faq.items[${m[1]}].${m[2]}`,
-        kind: "text",
-        multiline: m[2] === "a",
-        rows: m[2] === "a" ? 4 : undefined,
-      }),
-    },
-  ],
-  js_self_analysis: [
-    {
-      re: /^jsa-faq-item-(\d+)-(q|a)$/,
-      build: (m) => ({
-        id: m[0],
-        label: `FAQ ${Number(m[1]) + 1} · ${m[2] === "q" ? "質問" : "回答"}`,
-        path: `faq.items[${m[1]}].${m[2]}`,
-        kind: "text",
-        multiline: m[2] === "a",
-        rows: m[2] === "a" ? 4 : undefined,
-      }),
-    },
-  ],
-};
-
 export function findLpField(slug: string, id: string): LpFieldDef | undefined {
   const kind = getLpKind(slug);
   if (kind === "home") return undefined;
   const exact = FIELD_MAP_BY_KIND[kind].get(id);
   if (exact) return exact;
-  for (const { re, build } of DYNAMIC_FIELD_PATTERNS[kind] ?? []) {
-    const m = id.match(re);
-    if (m) {
-      const built = build(m);
-      if (built) return built;
-    }
-  }
-  return undefined;
+  const built = buildDynamicFieldDef(id, slug);
+  if (!built) return undefined;
+  return { ...built, kind: "text" };
 }
 
 export function getLpFieldElements(slug: string): ElementDefinition[] {
@@ -116,4 +46,17 @@ export function getLpFieldElements(slug: string): ElementDefinition[] {
 
 export function isRegisteredLpField(slug: string, id: string): boolean {
   return findLpField(slug, id) != null;
+}
+
+export function findArrayItemElementDefinition(
+  slug: string,
+  id: string,
+): ElementDefinition | undefined {
+  const parsed = parseArrayItemId(id, slug);
+  if (!parsed) return undefined;
+  return {
+    id: parsed.id,
+    label: getArrayItemLabel(parsed.def, parsed.index),
+    editorSection: parsed.id,
+  };
 }

--- a/client/src/pages/BtobSeminar.tsx
+++ b/client/src/pages/BtobSeminar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
-import { CmHtml, CmId, FieldStylesProvider } from "@/components/contents-manager/CmId";
+import { CmArrayItem, CmHtml, CmId, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import { fetchContentBySlug } from "@/lib/content-loader";
 import { useCmPreviewPage } from "@/hooks/useCmPreviewPage";
 import { scrollToAnchor } from "@/lib/smooth-scroll";
@@ -168,13 +168,6 @@ export default function BtobSeminar() {
     return () => io.disconnect();
   }, [content]);
 
-  const h = content.hero;
-  const heroInfo = (() => {
-    const padded = [...h.info];
-    while (padded.length < 4) padded.push({ label: "", value: "" });
-    return padded.slice(0, 4);
-  })();
-
   return (
     <FieldStylesProvider value={content.fieldStyles}>
     <div id="btob-seminar-page" ref={rootRef}>
@@ -222,15 +215,15 @@ export default function BtobSeminar() {
           </p>
 
           <div className="hero-info">
-            {heroInfo.map((item, i) => (
-              <div key={i} className="hero-info-item">
+            {content.hero.info.map((item, i) => (
+              <CmArrayItem key={i} id={`btob-hero-info-${i}`} className="hero-info-item">
                 <CmId id={`btob-hero-info-${i}-label`} as="span" className="hero-info-label">
                   {item.label}
                 </CmId>
                 <CmId id={`btob-hero-info-${i}-value`} as="span" className="hero-info-value">
                   {item.value}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
 
@@ -270,9 +263,11 @@ export default function BtobSeminar() {
 
             <ul className="empathy-checklist">
               {content.empathy.checklist.map((t, i) => (
-                <CmId key={i} id={`btob-empathy-checklist-${i}`} as="li">
-                  {t}
-                </CmId>
+                <CmArrayItem key={i} id={`btob-empathy-checklist-${i}`} style={{ display: "contents" }}>
+                  <CmId id={`btob-empathy-checklist-${i}`} as="li">
+                    {t}
+                  </CmId>
+                </CmArrayItem>
               ))}
             </ul>
           </div>
@@ -295,7 +290,7 @@ export default function BtobSeminar() {
 
           <div className="loop-diagram reveal">
             {content.structure.steps.map((s, i) => (
-              <div key={s.num} className="loop-step">
+              <CmArrayItem key={s.num} id={`btob-structure-step-${i}`} className="loop-step">
                 <CmId id={`btob-structure-step-${i}-num`} as="span" className="loop-step-num">
                   {s.num}
                 </CmId>
@@ -305,7 +300,7 @@ export default function BtobSeminar() {
                 <CmId id={`btob-structure-step-${i}-desc`} as="div" className="loop-step-desc">
                   {s.desc}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
 
@@ -379,7 +374,7 @@ export default function BtobSeminar() {
 
           <div className="experience-grid reveal">
             {content.experience.items.map((ex, i) => (
-              <div key={ex.num} className="experience-card">
+              <CmArrayItem key={ex.num} id={`btob-experience-item-${i}`} className="experience-card">
                 <CmId id={`btob-experience-item-${i}-num`} as="span" className="experience-num">
                   {ex.num}
                 </CmId>
@@ -389,7 +384,7 @@ export default function BtobSeminar() {
                 <div className="experience-desc">
                   <CmHtml id={`btob-experience-item-${i}-descHtml`} html={ex.descHtml} as="span" />
                 </div>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -411,7 +406,7 @@ export default function BtobSeminar() {
 
           <div className="takeaway-list reveal">
             {content.takeaway.cards.map((c, i) => (
-              <div key={i} className="takeaway-card">
+              <CmArrayItem key={i} id={`btob-takeaway-card-${i}`} className="takeaway-card">
                 <CmId id={`btob-takeaway-card-${i}-icon`} as="div" className="takeaway-icon">
                   {c.icon}
                 </CmId>
@@ -421,7 +416,7 @@ export default function BtobSeminar() {
                 <CmId id={`btob-takeaway-card-${i}-desc`} as="div" className="takeaway-desc">
                   {c.desc}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -460,9 +455,11 @@ export default function BtobSeminar() {
           <div className="audience-grid reveal">
             <ul className="audience-list">
               {content.audience.items.map((t, i) => (
-                <CmId key={i} id={`btob-audience-item-${i}`} as="li">
-                  {t}
-                </CmId>
+                <CmArrayItem key={i} id={`btob-audience-item-${i}`} style={{ display: "contents" }}>
+                  <CmId id={`btob-audience-item-${i}`} as="li">
+                    {t}
+                  </CmId>
+                </CmArrayItem>
               ))}
             </ul>
 
@@ -494,7 +491,7 @@ export default function BtobSeminar() {
 
           <div className="hosts-grid reveal">
             {content.hosts.cards.map((host, i) => (
-              <div key={i} className={`host-card ${i === 0 ? "primary" : "secondary"}`}>
+              <CmArrayItem key={i} id={`btob-hosts-card-${i}`} className={`host-card ${i === 0 ? "primary" : "secondary"}`}>
                 <CmId id={`btob-hosts-card-${i}-role`} as="div" className="host-role">
                   {host.role}
                 </CmId>
@@ -507,7 +504,7 @@ export default function BtobSeminar() {
                 <CmId id={`btob-hosts-card-${i}-desc`} as="div" className="host-desc">
                   {host.desc}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -528,12 +525,14 @@ export default function BtobSeminar() {
             <tbody>
               {content.details.rows.map((row, i) => (
                 <tr key={i}>
-                  <CmId id={`btob-details-row-${i}-th`} as="th">
-                    {row.th}
-                  </CmId>
-                  <td>
-                    <CmHtml id={`btob-details-row-${i}-tdHtml`} html={row.tdHtml} as="span" />
-                  </td>
+                  <CmArrayItem id={`btob-details-row-${i}`} style={{ display: "contents" }}>
+                    <CmId id={`btob-details-row-${i}-th`} as="th">
+                      {row.th}
+                    </CmId>
+                    <td>
+                      <CmHtml id={`btob-details-row-${i}-tdHtml`} html={row.tdHtml} as="span" />
+                    </td>
+                  </CmArrayItem>
                 </tr>
               ))}
             </tbody>
@@ -554,7 +553,7 @@ export default function BtobSeminar() {
 
           <div className="faq-list reveal">
             {content.faq.items.map((item, i) => (
-              <div key={i} className="faq-item">
+              <CmArrayItem key={i} id={`btob-faq-item-${i}`} className="faq-item">
                 <span className="faq-marker">Q.</span>
                 <div>
                   <CmId id={`btob-faq-item-${i}-q`} as="div" className="faq-q">
@@ -564,7 +563,7 @@ export default function BtobSeminar() {
                     {item.a}
                   </CmId>
                 </div>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>

--- a/client/src/pages/ContentsManager.tsx
+++ b/client/src/pages/ContentsManager.tsx
@@ -36,6 +36,7 @@ import {
 import { applyContentToLocalStorage, fetchContentBySlug, fetchContentManifest } from "@/lib/content-loader";
 import { applyDraftToPreviewStorage } from "@/lib/content-manager/preview-storage";
 import { broadcastCmDraft } from "@/lib/content-manager/cm-preview-sync";
+import type { ArrayMutationContext } from "@/lib/content-manager/array-item-ops";
 import { fetchRepoConfig, saveContentToGitHub, saveContentViaApi, type RepoConfig } from "@/lib/github-content-api";
 import { getContentRepoPathForSlug, TOP_SLUG } from "@/lib/lp-slug";
 import type { ContentPayload } from "@/types/content-payload";
@@ -116,6 +117,7 @@ export default function ContentsManager() {
   );
   const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
   const [selectedElementLabel, setSelectedElementLabel] = useState<string | null>(null);
+  const [selectedSelectKind, setSelectedSelectKind] = useState<"field" | "array" | "auto">("field");
   const [sheetOpen, setSheetOpen] = useState(false);
 
   useEffect(() => {
@@ -139,6 +141,7 @@ export default function ContentsManager() {
     if (!unlocked || !selectedSlug) return;
     setSelectedElementId(null);
     setSelectedElementLabel(null);
+    setSelectedSelectKind("field");
     setSheetOpen(false);
     (async () => {
       const payload = await fetchContentBySlug(selectedSlug);
@@ -147,8 +150,8 @@ export default function ContentsManager() {
         setHeroImageUrl(payload.hero ?? null);
         setHeroImageUrlMobile(payload.heroMobile ?? null);
         setFeatures(
-          payload.features && payload.features.length >= 3
-            ? payload.features.slice(0, 3)
+          payload.features && payload.features.length > 0
+            ? payload.features
             : [...DEFAULT_FEATURES],
         );
         setEventImages(payload.eventImages && payload.eventImages.length > 0 ? payload.eventImages : []);
@@ -209,7 +212,7 @@ export default function ContentsManager() {
       heroMobile: heroImageUrlMobile ?? null,
       eventImages: eventImages.length > 0 ? eventImages : undefined,
       events: events.length > 0 ? events : undefined,
-      features: features.slice(0, 3),
+      features: features.length > 0 ? features : undefined,
       paletteId: paletteId ?? null,
       copy: homeCopy,
       ...(selectedSlug === "campaign2603"
@@ -324,7 +327,7 @@ export default function ContentsManager() {
   };
 
   const handleFeatureUpdate = (index: number, patch: Partial<FeatureItem>) => {
-    persistFeatures(features.slice(0, 3).map((f, i) => (i === index ? { ...f, ...patch } : f)));
+    persistFeatures(features.map((f, i) => (i === index ? { ...f, ...patch } : f)));
   };
 
   const handleDownloadJson = () => {
@@ -377,14 +380,48 @@ export default function ContentsManager() {
     }
   };
 
-  const handleElementSelect = useCallback((id: string, label?: string) => {
-    setSelectedElementId(id);
-    setSelectedElementLabel(label ?? null);
-    setSheetOpen(true);
-  }, []);
+  const handleElementSelect = useCallback(
+    (id: string, label?: string, selectKind: "field" | "array" | "auto" = "field") => {
+      setSelectedElementId(id);
+      setSelectedElementLabel(label ?? null);
+      setSelectedSelectKind(selectKind);
+      setSheetOpen(true);
+    },
+    [],
+  );
 
   const defaultLineHref =
     selectedSlug === "campaign2603" ? LINE_CAMPAIGN2603_SIGNUP_URL : LINE_KS_SIGNUP_URL;
+
+  const arrayMutationContext = useMemo<ArrayMutationContext | null>(() => {
+    return {
+      homeCopy,
+      onHomeCopyChange: (next) => {
+        setHomeCopy(next);
+        setStoredHomeCopy(next);
+      },
+      features,
+      onFeaturesChange: persistFeatures,
+      btobSeminarContent,
+      onBtobSeminarChange: (next) => setBtobSeminarContent(next),
+      selfReflectionContent,
+      onSelfReflectionChange: (next) => setSelfReflectionContent(next),
+      startingJobHuntingContent,
+      onStartingJobHuntingChange: (next) => setStartingJobHuntingContent(next),
+      selfStanceContent,
+      onSelfStanceChange: (next) => setSelfStanceContent(next),
+      jsSelfAnalysisContent,
+      onJsSelfAnalysisChange: (next) => setJsSelfAnalysisContent(next),
+    };
+  }, [
+    homeCopy,
+    features,
+    btobSeminarContent,
+    selfReflectionContent,
+    startingJobHuntingContent,
+    selfStanceContent,
+    jsSelfAnalysisContent,
+  ]);
 
   const homeElementEditorProps: HomeElementEditorProps | null = useMemo(
     () => ({
@@ -609,7 +646,7 @@ export default function ContentsManager() {
           <ul className="space-y-2 text-sm text-[#5C3E2A]">
             <li>
               <span className="text-[#d4844b] font-bold">1.</span>{" "}
-              プレビュー上の要素をクリックすると、下から編集パレットが開きます。
+              テキスト部分をクリックすると文言の編集パレット、項目の余白（点線枠）をクリックすると追加・削除パレットが開きます。
             </li>
             <li>
               <span className="text-[#d4844b] font-bold">2.</span>{" "}
@@ -633,7 +670,9 @@ export default function ContentsManager() {
         selectedSlug={selectedSlug}
         elementId={selectedElementId}
         elementLabel={selectedElementLabel}
+        selectKind={selectedSelectKind}
         homeProps={homeElementEditorProps}
+        arrayMutationContext={arrayMutationContext}
         btobSeminarContent={btobSeminarContent}
         onBtobSeminarChange={setBtobSeminarContent}
         selfReflectionContent={selfReflectionContent}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useSmoothScroll } from "@/hooks/useSmoothScroll";
 import { useCmPreviewPage } from "@/hooks/useCmPreviewPage";
+import { CmArrayItem } from "@/components/contents-manager/CmId";
 import { useHomeDynamicLinks } from "@/hooks/useHomeDynamicLinks";
 import {
   DEFAULT_EVENT_FLOW_IMAGE_PATHS,
@@ -133,7 +134,7 @@ export default function Home({ lpSlug }: HomeProps) {
     setHeroImageMobileUrl(payload.heroMobile || null);
     setHeroImageLoadError(false);
     setFeatures(
-      payload.features && payload.features.length >= 3 ? payload.features.slice(0, 3) : getStoredFeatures(),
+      payload.features && payload.features.length > 0 ? payload.features : getStoredFeatures(),
     );
     setFeatureImageErrors(new Set());
     if (payload.paletteId) setPaletteId(payload.paletteId);
@@ -213,7 +214,7 @@ export default function Home({ lpSlug }: HomeProps) {
       setHeroImageUrl(local.hero ?? DEFAULT_HERO_IMAGE_PATH);
       setHeroImageMobileUrl(local.heroMobile || null);
       setHeroImageLoadError(false);
-      setFeatures(local.features && local.features.length >= 3 ? local.features.slice(0, 3) : getStoredFeatures());
+      setFeatures(local.features && local.features.length > 0 ? local.features : getStoredFeatures());
       setFeatureImageErrors(new Set());
       setHomeCopy(getStoredHomeCopy());
     })();
@@ -653,7 +654,12 @@ export default function Home({ lpSlug }: HomeProps) {
           </div>
           <div className="grid md:grid-cols-3 gap-6">
             {homeCopy.values.items.map((item, i) => (
-              <div key={i} className="bg-white border border-lp-border rounded-3xl p-10 hover:shadow-lg hover:-translate-y-0.5 transition-all opacity-0 animate-fadeUp" style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+              <CmArrayItem
+                key={i}
+                id={`values-card-${i}`}
+                className="bg-white border border-lp-border rounded-3xl p-10 hover:shadow-lg hover:-translate-y-0.5 transition-all opacity-0 animate-fadeUp"
+                style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}
+              >
                 <div className="flex flex-wrap gap-6">
                   <div className="text-4xl font-bold text-[#ffd7c3] shrink-0" style={{ fontFamily: "'Shippori Mincho', serif" }}>{String(i + 1).padStart(2, "0")}</div>
                   <div className="flex-1 min-w-0">
@@ -675,7 +681,7 @@ export default function Home({ lpSlug }: HomeProps) {
                     </div>
                   ) : null}
                 </div>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -694,7 +700,12 @@ export default function Home({ lpSlug }: HomeProps) {
           <div className="relative">
             <div className="absolute left-6 top-6 bottom-6 w-0.5 bg-gradient-to-b from-lp-primary to-lp-accent-light"></div>
             {homeCopy.eventFlow.steps.map((item, i) => (
-              <div key={i} className="flex gap-6 mb-8 opacity-0 animate-fadeUp" style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards' }}>
+              <CmArrayItem
+                key={i}
+                id={`event-flow-step-${i}`}
+                className="flex gap-6 mb-8 opacity-0 animate-fadeUp"
+                style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards' }}
+              >
                 <div className="flex-shrink-0 w-12 h-12 rounded-full bg-white border-2 border-lp-primary flex items-center justify-center font-bold text-lp-text-heading relative z-10" style={{ fontFamily: "'Shippori Mincho', serif" }}>
                   {String(i + 1).padStart(2, "0")}
                 </div>
@@ -703,7 +714,7 @@ export default function Home({ lpSlug }: HomeProps) {
                   <p className="text-xs text-lp-primary font-medium mb-1" data-cm-id={`event-flow-step-${i}-time`} style={cms(`event-flow-step-${i}-time`)}>{item.time}</p>
                   <p className="text-sm text-lp-text-body leading-relaxed" data-cm-id={`event-flow-step-${i}-description`} style={cms(`event-flow-step-${i}-description`)}>{item.description}</p>
                 </div>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
 
@@ -774,10 +785,10 @@ export default function Home({ lpSlug }: HomeProps) {
             </h2>
           </div>
           <div className="grid md:grid-cols-3 gap-6">
-            {features.length === 0 ? null : features.slice(0, 3).map((item, i) => {
+            {features.length === 0 ? null : features.map((item, i) => {
               const hasImage = item.imageUrl != null && item.imageUrl.trim() !== "" && !featureImageErrors.has(i);
               return (
-              <div key={i} className="bg-white border border-lp-border rounded-3xl p-8 hover:shadow-lg hover:-translate-y-0.5 transition-all opacity-0 animate-fadeUp overflow-hidden" style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+              <CmArrayItem key={i} id={`feature-${i}`} className="bg-white border border-lp-border rounded-3xl p-8 hover:shadow-lg hover:-translate-y-0.5 transition-all opacity-0 animate-fadeUp overflow-hidden" style={{ animationDelay: `${i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
                 {hasImage && (
                   <div className="-mx-8 -mt-8 mb-6 h-[180px] overflow-hidden bg-lp-bg-warm shadow-lg ring-1 ring-black/5 relative" data-cm-id={`feature-${i}-image`}>
                     <picture className="absolute inset-0 block w-full h-full">
@@ -806,7 +817,7 @@ export default function Home({ lpSlug }: HomeProps) {
                 </div>
                 <h3 className="text-lg font-bold text-lp-text-heading leading-tight mb-3" style={cms(`feature-${i}-title`, MINCHO_STYLE)} data-cm-id={`feature-${i}-title`}>{item.title}</h3>
                 <p className="text-sm text-lp-text-heading leading-relaxed whitespace-pre-line" data-cm-id={`feature-${i}-body`} style={cms(`feature-${i}-body`)}>{item.body}</p>
-              </div>
+              </CmArrayItem>
             );})}
           </div>
         </div>
@@ -823,12 +834,12 @@ export default function Home({ lpSlug }: HomeProps) {
           </div>
           <div className="grid md:grid-cols-3 gap-6">
             {homeCopy.voices.items.map((item, i) => (
-              <div key={i} className="bg-white border border-lp-border rounded-2xl p-6 opacity-0 animate-fadeUp" style={{ animationDelay: `${(i % 3) * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+              <CmArrayItem key={i} id={`voices-card-${i}`} className="bg-white border border-lp-border rounded-2xl p-6 opacity-0 animate-fadeUp" style={{ animationDelay: `${(i % 3) * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
                 <p className="text-sm text-lp-text-muted leading-relaxed mb-4 border-l-3 border-lp-primary pl-4" style={cms(`voices-card-${i}-quote`, MINCHO_STYLE)} data-cm-id={`voices-card-${i}-quote`}>{item.quote}</p>
                 <p className="text-xs text-lp-text-body font-medium" data-cm-id={`voices-card-${i}-attribution`} style={cms(`voices-card-${i}-attribution`)}>
                   {item.attribution}
                 </p>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
           <div className="mt-10 w-full max-w-sm mx-auto hidden md:block">
@@ -863,14 +874,14 @@ export default function Home({ lpSlug }: HomeProps) {
             </div>
             <div className="space-y-3 mb-9">
             {homeCopy.screening.criteria.map((item, i) => (
-              <div key={i} className="flex items-start gap-3 p-4 bg-white border border-lp-border rounded-2xl opacity-0 animate-fadeUp" style={{ animationDelay: `${0.12 + i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+              <CmArrayItem key={i} id={`screening-criterion-${i}`} className="flex items-start gap-3 p-4 bg-white border border-lp-border rounded-2xl opacity-0 animate-fadeUp" style={{ animationDelay: `${0.12 + i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
                 <div className="flex-shrink-0 w-7 h-7 rounded-full bg-lp-bg-warm flex items-center justify-center text-lp-primary mt-0.5">
                   <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <path d="M13 4L6 11L3 8"/>
                   </svg>
                 </div>
                 <p className="text-sm text-lp-text-heading pt-0.5" data-cm-id={`screening-criterion-${i}`} style={cms(`screening-criterion-${i}`)}>{item}</p>
-              </div>
+              </CmArrayItem>
             ))}
             </div>
             <div className="p-6 bg-lp-bg-warm rounded-2xl text-center opacity-0 animate-fadeUp" style={{ animationDelay: '0.6s', animationFillMode: 'forwards' }} data-cm-id="screening-trust">
@@ -890,7 +901,7 @@ export default function Home({ lpSlug }: HomeProps) {
             <p className="text-xs text-lp-primary text-center mb-5" data-cm-id="safety-subheading" style={cms("safety-subheading")}>{homeCopy.safety.subheading}</p>
             <div className="space-y-3">
               {homeCopy.safety.items.map((item, i) => (
-                <div key={i} className="flex gap-3 p-4 bg-white border border-lp-border rounded-2xl opacity-0 animate-fadeUp" style={{ animationDelay: `${0.6 + i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+                <CmArrayItem key={i} id={`safety-item-${i}`} className="flex gap-3 p-4 bg-white border border-lp-border rounded-2xl opacity-0 animate-fadeUp" style={{ animationDelay: `${0.6 + i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
                   <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-lp-bg-warm flex items-center justify-center text-lp-primary">
                     {i === 0 && (
                       <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -913,7 +924,7 @@ export default function Home({ lpSlug }: HomeProps) {
                     <p className="text-sm font-medium text-lp-text-heading mb-0.5" data-cm-id={`safety-item-${i}-title`} style={cms(`safety-item-${i}-title`)}>{item.title}</p>
                     <p className="text-xs text-lp-text-body leading-relaxed" data-cm-id={`safety-item-${i}-description`} style={cms(`safety-item-${i}-description`)}>{item.description}</p>
                   </div>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
           </div>
@@ -960,7 +971,7 @@ export default function Home({ lpSlug }: HomeProps) {
 
               if (isCmPreview) {
                 return (
-                  <div key={i} className="border-b border-lp-border">
+                  <CmArrayItem key={i} id={`faq-item-${i}`} className="border-b border-lp-border">
                     <div className="flex items-center justify-between gap-3 py-5">
                       <span
                         className="flex-1 min-w-0 text-left text-lp-text-heading font-medium text-sm"
@@ -980,12 +991,13 @@ export default function Home({ lpSlug }: HomeProps) {
                         {item.answer}
                       </div>
                     )}
-                  </div>
+                  </CmArrayItem>
                 );
               }
 
               return (
-              <details key={i} className="border-b border-lp-border group">
+              <CmArrayItem key={i} id={`faq-item-${i}`} className="border-b border-lp-border">
+              <details className="group">
                 <summary className="py-5 cursor-pointer flex items-center justify-between gap-3 text-lp-text-heading font-medium text-sm hover:text-lp-primary transition-colors list-none [&::-webkit-details-marker]:hidden">
                   {item.question}
                   <span className="flex-shrink-0 w-7 h-7 rounded-full bg-lp-bg-warm flex items-center justify-center group-open:bg-lp-border transition-colors pointer-events-none">
@@ -1010,6 +1022,7 @@ export default function Home({ lpSlug }: HomeProps) {
                   {item.answer}
                 </div>
               </details>
+              </CmArrayItem>
             );
             })}
           </div>

--- a/client/src/pages/JsSelfAnalysis.tsx
+++ b/client/src/pages/JsSelfAnalysis.tsx
@@ -9,7 +9,7 @@ import {
   mergeJsSelfAnalysisContent,
   type JsSelfAnalysisContent,
 } from "@/types/js-self-analysis";
-import { CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
+import { CmArrayItem, CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import "./js-self-analysis.css";
 
 const STORAGE_KEY = "js_self_analysis_content_v1";
@@ -229,7 +229,7 @@ export default function JsSelfAnalysis() {
             <div className="hero-inner">
               <div className="hero-info-card">
                 {c.hero.infoRows.map((row, i) => (
-                  <div key={i} className="hero-info-row">
+                  <CmArrayItem key={i} id={`jsa-hero-info-row-${i}`} className="hero-info-row">
                     {HERO_ICONS[i] ?? HERO_ICONS[0]}
                     <div>
                       <CmId id={`jsa-hero-info-row-${i}-label`} className="hero-info-label">
@@ -239,7 +239,7 @@ export default function JsSelfAnalysis() {
                         {row.value}
                       </CmId>
                     </div>
-                  </div>
+                  </CmArrayItem>
                 ))}
               </div>
               <div className="hero-cta-wrap">
@@ -267,12 +267,12 @@ export default function JsSelfAnalysis() {
             </h2>
             <ul className="pain-list">
               {c.empathy.items.map((item, i) => (
-                <li key={i} className="pain-item">
+                <CmArrayItem key={i} id={`jsa-empathy-item-${i}`} className="pain-item">
                   <div className="pain-dot" />
                   <CmId id={`jsa-empathy-item-${i}`} as="p" className="pain-text">
                     {item}
                   </CmId>
-                </li>
+                </CmArrayItem>
               ))}
             </ul>
             <CmHtml id="jsa-empathy-close" className="empathy-close" html={c.empathy.closeHtml} as="p" />
@@ -313,12 +313,12 @@ export default function JsSelfAnalysis() {
             </CmId>
             <ul className="outcome-list">
               {c.solution.outcomes.map((o, i) => (
-                <li key={i} className="outcome-item">
+                <CmArrayItem key={i} id={`jsa-solution-outcome-${i}`} className="outcome-item">
                   <div className="outcome-check" />
                   <CmId id={`jsa-solution-outcome-${i}`} as="span" className="outcome-text">
                     {o}
                   </CmId>
-                </li>
+                </CmArrayItem>
               ))}
             </ul>
           </div>
@@ -334,7 +334,7 @@ export default function JsSelfAnalysis() {
             </CmId>
             <div className="timeline">
               {c.schedule.steps.map((step, i) => (
-                <div key={i} className="timeline-item">
+                <CmArrayItem key={i} id={`jsa-schedule-step-${i}`} className="timeline-item">
                   <div className="timeline-dot" />
                   <CmId id={`jsa-schedule-step-${i}-label`} className="timeline-label">
                     {step.label}
@@ -345,17 +345,17 @@ export default function JsSelfAnalysis() {
                   <CmId id={`jsa-schedule-step-${i}-desc`} className="timeline-desc">
                     {step.desc}
                   </CmId>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
             <div className="schedule-notes">
               {c.schedule.notes.map((note, i) => (
-                <div key={i} className="schedule-note">
+                <CmArrayItem key={i} id={`jsa-schedule-note-${i}`} className="schedule-note">
                   <div className="note-icon" />
                   <CmId id={`jsa-schedule-note-${i}`} as="span">
                     {note}
                   </CmId>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
             <div className="schedule-cta-wrap">
@@ -401,10 +401,12 @@ export default function JsSelfAnalysis() {
             <ul className="faci-bio">
               {c.facilitator.bio.map((line, i) => (
                 <li key={i}>
-                  <span className="bio-dot" />
-                  <CmId id={`jsa-facilitator-bio-${i}`} as="span">
-                    {line}
-                  </CmId>
+                  <CmArrayItem id={`jsa-facilitator-bio-${i}`} style={{ display: "contents" }}>
+                    <span className="bio-dot" />
+                    <CmId id={`jsa-facilitator-bio-${i}`} as="span">
+                      {line}
+                    </CmId>
+                  </CmArrayItem>
                 </li>
               ))}
             </ul>
@@ -424,7 +426,7 @@ export default function JsSelfAnalysis() {
             </CmId>
             <div className="voice-list">
               {c.voices.items.map((v, i) => (
-                <div key={i} className="voice-card">
+                <CmArrayItem key={i} id={`jsa-voices-item-${i}`} className="voice-card">
                   <div className="voice-head">
                     <div className="voice-mark">&ldquo;</div>
                     <CmId id={`jsa-voices-item-${i}-who`} as="span" className="voice-who">
@@ -434,7 +436,7 @@ export default function JsSelfAnalysis() {
                   <CmId id={`jsa-voices-item-${i}-text`} as="p" className="voice-text">
                     {v.text}
                   </CmId>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
           </div>
@@ -452,16 +454,18 @@ export default function JsSelfAnalysis() {
               <tbody>
                 {c.eventInfo.rows.map((row, i) => (
                   <tr key={i}>
-                    <td>
-                      <CmId id={`jsa-event-info-row-${i}-label`} as="span">
-                        {row.label}
-                      </CmId>
-                    </td>
-                    <td>
-                      <CmId id={`jsa-event-info-row-${i}-value`} as="span">
-                        {row.value}
-                      </CmId>
-                    </td>
+                    <CmArrayItem id={`jsa-event-info-row-${i}`} style={{ display: "contents" }}>
+                      <td>
+                        <CmId id={`jsa-event-info-row-${i}-label`} as="span">
+                          {row.label}
+                        </CmId>
+                      </td>
+                      <td>
+                        <CmId id={`jsa-event-info-row-${i}-value`} as="span">
+                          {row.value}
+                        </CmId>
+                      </td>
+                    </CmArrayItem>
                   </tr>
                 ))}
               </tbody>
@@ -487,12 +491,12 @@ export default function JsSelfAnalysis() {
             </CmId>
             <div className="who-list">
               {c.forWho.items.map((item, i) => (
-                <div key={i} className="who-item">
+                <CmArrayItem key={i} id={`jsa-forwho-item-${i}`} className="who-item">
                   <div className="who-num">{i + 1}</div>
                   <CmId id={`jsa-forwho-item-${i}`} as="span" className="who-text">
                     {item}
                   </CmId>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
           </div>
@@ -508,7 +512,7 @@ export default function JsSelfAnalysis() {
             </CmId>
             <div className="faq-list">
               {c.faq.items.map((item, i) => (
-                <div key={i} className="faq-item">
+                <CmArrayItem key={i} id={`jsa-faq-item-${i}`} className="faq-item">
                   <div className="faq-q">
                     <span className="faq-q-icon">Q</span>
                     <CmId id={`jsa-faq-item-${i}-q`} as="span">
@@ -518,7 +522,7 @@ export default function JsSelfAnalysis() {
                   <CmId id={`jsa-faq-item-${i}-a`} className="faq-a">
                     {item.a}
                   </CmId>
-                </div>
+                </CmArrayItem>
               ))}
             </div>
           </div>

--- a/client/src/pages/SelfReflection.tsx
+++ b/client/src/pages/SelfReflection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { CmHtml, CmId, FieldStylesProvider } from "@/components/contents-manager/CmId";
+import { CmArrayItem, CmHtml, CmId, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import { fetchContentBySlug } from "@/lib/content-loader";
 import { useCmPreviewPage } from "@/hooks/useCmPreviewPage";
 import type { ContentPayload } from "@/types/content-payload";
@@ -660,9 +660,11 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           </div>
           <div className="s01b-tags">
             {content.eventInfo.tags.map((t, i) => (
-              <CmId key={`${t}-${i}`} id={`sr-event-info-tag-${i}`} as="span" className="s01b-tag">
-                {t}
-              </CmId>
+              <CmArrayItem key={`${t}-${i}`} id={`sr-event-info-tag-${i}`} style={{ display: "contents" }}>
+                <CmId id={`sr-event-info-tag-${i}`} as="span" className="s01b-tag">
+                  {t}
+                </CmId>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -675,10 +677,10 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           </CmId>
           <ul className="issue-list">
             {content.issue.items.map((txt, i) => (
-              <li key={i} className="issue-item">
+              <CmArrayItem key={i} id={`sr-issue-item-${i}`} className="issue-item">
                 <span className="issue-dot" />
                 <CmId id={`sr-issue-item-${i}`}>{txt}</CmId>
-              </li>
+              </CmArrayItem>
             ))}
           </ul>
         </div>
@@ -709,7 +711,9 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           <CmHtml id="sr-concept-copy" html={content.concept.copyHtml} as="p" className="concept-copy" />
           <div className="tag-grid">
             {content.concept.tagsHtml.map((html, i) => (
-              <CmHtml key={i} id={`sr-concept-tag-${i}`} html={html} as="span" className="concept-tag" />
+              <CmArrayItem key={i} id={`sr-concept-tag-${i}`} style={{ display: "contents" }}>
+                <CmHtml id={`sr-concept-tag-${i}`} html={html} as="span" className="concept-tag" />
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -722,7 +726,7 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           </CmId>
           <ul className="step-list">
             {content.steps.items.map((s, i) => (
-              <li key={i} className="step-item">
+              <CmArrayItem key={i} id={`sr-steps-item-${i}`} className="step-item">
                 <div className="step-num-block">
                   <span className="step-label">STEP</span>
                   <CmId id={`sr-steps-item-${i}-num`} as="span" className="step-num">
@@ -745,7 +749,7 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
                     </CmId>
                   ) : null}
                 </div>
-              </li>
+              </CmArrayItem>
             ))}
           </ul>
           <div className="step-img-row">
@@ -785,14 +789,14 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           </CmId>
           <div className="voice-grid">
             {content.voices.cards.map((v, i) => (
-              <div key={i} className="voice-card">
+              <CmArrayItem key={i} id={`sr-voices-card-${i}`} className="voice-card">
                 <CmId id={`sr-voices-card-${i}-change`} as="div" className="voice-change">
                   {v.change}
                 </CmId>
                 <CmId id={`sr-voices-card-${i}-quote`} as="div" className="voice-quote">
                   {v.quote}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -805,14 +809,14 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
           </CmId>
           <div className="safety-grid">
             {content.safety.items.map((it, i) => (
-              <div key={i} className="safety-item">
+              <CmArrayItem key={i} id={`sr-safety-item-${i}`} className="safety-item">
                 <CmId id={`sr-safety-item-${i}-label`} as="div" className="safety-label">
                   {it.label}
                 </CmId>
                 <CmId id={`sr-safety-item-${i}-desc`} as="div" className="safety-desc">
                   {it.desc}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -842,19 +846,16 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
             </div>
           </div>
           <div className="advisor-text">
-            {content.advisor.bio.slice(0, 3).map((p, i) => (
-              <CmId key={i} id={`sr-advisor-bio-${i}`} as="p" className="advisor-bio">
-                {p}
-              </CmId>
+            {content.advisor.bio.map((p, i) => (
+              <CmArrayItem key={i} id={`sr-advisor-bio-${i}`}>
+                <CmId id={`sr-advisor-bio-${i}`} as="p" className="advisor-bio">
+                  {p}
+                </CmId>
+              </CmArrayItem>
             ))}
             <CmId id="sr-advisor-highlight" as="div" className="advisor-highlight">
               {content.advisor.highlight}
             </CmId>
-            {content.advisor.bio.slice(3).map((p, i) => (
-              <CmId key={`tail-${i}`} id={`sr-advisor-bio-${i + 3}`} as="p" className="advisor-bio">
-                {p}
-              </CmId>
-            ))}
           </div>
         </div>
       </section>
@@ -868,7 +869,7 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
             {faqItems.map((it, i) => {
               const open = openFaqIndex === i;
               return (
-                <li key={i} className={`faq-item ${open ? "open" : ""}`}>
+                <CmArrayItem key={i} id={`sr-faq-item-${i}`} className={`faq-item ${open ? "open" : ""}`}>
                   {isCmPreview ? (
                     <div className="faq-q">
                       <span className="faq-q-label">Q</span>
@@ -905,7 +906,7 @@ footer { background:var(--brown-dark); color:rgba(255,255,255,0.6); padding:40px
                   <CmId id={`sr-faq-item-${i}-a`} as="div" className="faq-a">
                     {it.a}
                   </CmId>
-                </li>
+                </CmArrayItem>
               );
             })}
           </ul>

--- a/client/src/pages/SelfStance.tsx
+++ b/client/src/pages/SelfStance.tsx
@@ -11,7 +11,7 @@ import {
   type SelfStanceContent,
 } from "@/types/self-stance";
 import { EventInfoIcon } from "@/components/EventInfoIcon";
-import { CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
+import { CmArrayItem, CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import "./self-stance.css";
 
 const STORAGE_KEY = "self_stance_content_v1";
@@ -249,7 +249,7 @@ export default function SelfStance() {
         </CmId>
         <div className="info-grid">
           {c.eventInfo.rows.map((row, i) => (
-            <div key={i} className="info-row">
+            <CmArrayItem key={i} id={`ss-event-info-row-${i}`} className="info-row">
               <div className="info-icon">
                 <EventInfoIcon label={row.label} />
               </div>
@@ -261,7 +261,7 @@ export default function SelfStance() {
                   {row.value}
                 </CmId>
               </div>
-            </div>
+            </CmArrayItem>
           ))}
         </div>
       </div>
@@ -277,7 +277,9 @@ export default function SelfStance() {
           <ul className="emp-list">
             {c.empathy.items.map((item, i) => (
               <li key={i}>
-                <CmId id={`ss-problem-item-${i}`}>{item}</CmId>
+                <CmArrayItem id={`ss-problem-item-${i}`}>
+                  <CmId id={`ss-problem-item-${i}`}>{item}</CmId>
+                </CmArrayItem>
               </li>
             ))}
           </ul>
@@ -306,7 +308,9 @@ export default function SelfStance() {
           <ul className="benefit-list">
             {c.solution.benefits.map((b, i) => (
               <li key={i}>
-                <CmId id={`ss-solution-benefit-${i}`}>{b}</CmId>
+                <CmArrayItem id={`ss-solution-benefit-${i}`}>
+                  <CmId id={`ss-solution-benefit-${i}`}>{b}</CmId>
+                </CmArrayItem>
               </li>
             ))}
           </ul>
@@ -330,7 +334,7 @@ export default function SelfStance() {
           </h2>
           <div className="flow-steps">
             {c.program.steps.map((step, i) => (
-              <div key={i} className="flow-step">
+              <CmArrayItem key={i} id={`ss-program-step-${i}`} className="flow-step">
                 <div className="flow-step-left">
                   <CmId id={`ss-program-step-${i}-num`} as="span" className="flow-step-num">
                     {step.num}
@@ -346,7 +350,7 @@ export default function SelfStance() {
                 <CmId id={`ss-program-step-${i}-description`} className="flow-step-right">
                   {step.description}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
           <div className="flow-points">
@@ -356,7 +360,9 @@ export default function SelfStance() {
             <ul>
               {c.program.points.map((p, i) => (
                 <li key={i}>
-                  <CmId id={`ss-program-point-${i}`}>{p}</CmId>
+                  <CmArrayItem id={`ss-program-point-${i}`}>
+                    <CmId id={`ss-program-point-${i}`}>{p}</CmId>
+                  </CmArrayItem>
                 </li>
               ))}
             </ul>
@@ -390,7 +396,9 @@ export default function SelfStance() {
               <ul className="faci-list">
                 {c.facilitator.bio.map((line, i) => (
                   <li key={i}>
-                    <CmId id={`ss-facilitator-bio-${i}`}>{line}</CmId>
+                    <CmArrayItem id={`ss-facilitator-bio-${i}`}>
+                      <CmId id={`ss-facilitator-bio-${i}`}>{line}</CmId>
+                    </CmArrayItem>
                   </li>
                 ))}
               </ul>
@@ -412,14 +420,14 @@ export default function SelfStance() {
           </CmId>
           <div className="voice-grid">
             {c.voices.items.map((v, i) => (
-              <div key={i} className="voice-card">
+              <CmArrayItem key={i} id={`ss-voices-item-${i}`} className="voice-card">
                 <CmId id={`ss-voices-item-${i}-who`} className="voice-who">
                   {v.who}
                 </CmId>
                 <CmId id={`ss-voices-item-${i}-text`} className="voice-text">
                   {v.text}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
           {c.voices.note ? <p className="voice-note">{c.voices.note}</p> : null}
@@ -438,12 +446,14 @@ export default function SelfStance() {
             <tbody>
               {c.detail.scheduleRows.map((row, i) => (
                 <tr key={i}>
-                  <td>
-                    <CmId id={`ss-detail-row-${i}-label`}>{row.label}</CmId>
-                  </td>
-                  <td>
-                    <CmId id={`ss-detail-row-${i}-value`}>{row.value}</CmId>
-                  </td>
+                  <CmArrayItem id={`ss-detail-row-${i}`} style={{ display: "contents" }}>
+                    <td>
+                      <CmId id={`ss-detail-row-${i}-label`}>{row.label}</CmId>
+                    </td>
+                    <td>
+                      <CmId id={`ss-detail-row-${i}-value`}>{row.value}</CmId>
+                    </td>
+                  </CmArrayItem>
                 </tr>
               ))}
             </tbody>
@@ -478,7 +488,9 @@ export default function SelfStance() {
           <ul className="target-list">
             {c.target.items.map((item, i) => (
               <li key={i}>
-                <CmId id={`ss-target-item-${i}`}>{item}</CmId>
+                <CmArrayItem id={`ss-target-item-${i}`}>
+                  <CmId id={`ss-target-item-${i}`}>{item}</CmId>
+                </CmArrayItem>
               </li>
             ))}
           </ul>
@@ -495,14 +507,14 @@ export default function SelfStance() {
           </CmId>
           <div className="faq-list">
             {c.faq.items.map((item, i) => (
-              <div key={i} className="faq-item">
+              <CmArrayItem key={i} id={`ss-faq-item-${i}`} className="faq-item">
                 <CmId id={`ss-faq-item-${i}-q`} className="faq-q">
                   {item.q}
                 </CmId>
                 <CmId id={`ss-faq-item-${i}-a`} className="faq-a">
                   {item.a}
                 </CmId>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -514,9 +526,11 @@ export default function SelfStance() {
         </h2>
         <div className="final-body">
           {c.finalCta.paragraphs.map((p, i) => (
-            <CmId key={i} id={`ss-final-cta-paragraph-${i}`} as="p">
-              {p}
-            </CmId>
+            <CmArrayItem key={i} id={`ss-final-cta-paragraph-${i}`}>
+              <CmId id={`ss-final-cta-paragraph-${i}`} as="p">
+                {p}
+              </CmId>
+            </CmArrayItem>
           ))}
         </div>
         <CtaButton
@@ -532,9 +546,9 @@ export default function SelfStance() {
 
       <footer className="page-footer">
         {c.footer.lines.map((line, i) => (
-          <CmId key={i} id={`ss-footer-line-${i}`}>
-            {line}
-          </CmId>
+          <CmArrayItem key={i} id={`ss-footer-line-${i}`}>
+            <CmId id={`ss-footer-line-${i}`}>{line}</CmId>
+          </CmArrayItem>
         ))}
         <CmId id="ss-footer-copyright">{c.footer.copyright}</CmId>
       </footer>

--- a/client/src/pages/StartingJobHunting.tsx
+++ b/client/src/pages/StartingJobHunting.tsx
@@ -11,7 +11,7 @@ import {
   type StartingJobHuntingContent,
 } from "@/types/starting-job-hunting";
 import { EventInfoIcon } from "@/components/EventInfoIcon";
-import { CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
+import { CmArrayItem, CmId, CmHtml, FieldStylesProvider } from "@/components/contents-manager/CmId";
 import "./starting-job-hunting.css";
 
 const STORAGE_KEY = "starting_job_hunting_content_v1";
@@ -230,7 +230,7 @@ export default function StartingJobHunting() {
           </CmId>
           <div className="event-info-rows">
             {c.eventInfo.rows.map((row, i) => (
-              <div key={i} className="event-info-row">
+              <CmArrayItem key={i} id={`sjh-event-info-row-${i}`} className="event-info-row">
                 <div className="event-info-icon">
                   <EventInfoIcon label={row.label} />
                 </div>
@@ -247,7 +247,7 @@ export default function StartingJobHunting() {
                     </CmId>
                   ) : null}
                 </div>
-              </div>
+              </CmArrayItem>
             ))}
           </div>
         </div>
@@ -263,7 +263,9 @@ export default function StartingJobHunting() {
         <ul className="problem-list">
           {c.problem.items.map((item, i) => (
             <li key={i}>
-              <CmId id={`sjh-problem-item-${i}`}>{item}</CmId>
+              <CmArrayItem id={`sjh-problem-item-${i}`}>
+                <CmId id={`sjh-problem-item-${i}`}>{item}</CmId>
+              </CmArrayItem>
             </li>
           ))}
         </ul>
@@ -283,9 +285,13 @@ export default function StartingJobHunting() {
         </h2>
         <div className="bridge-box">
           {c.insight.paragraphs.map((p, i) => (
-            <p key={i} style={{ marginBottom: i < c.insight.paragraphs.length - 1 ? "1em" : 0 }}>
+            <CmArrayItem
+              key={i}
+              id={`sjh-insight-paragraph-${i}`}
+              style={{ marginBottom: i < c.insight.paragraphs.length - 1 ? "1em" : 0 }}
+            >
               <CmId id={`sjh-insight-paragraph-${i}`}>{p}</CmId>
-            </p>
+            </CmArrayItem>
           ))}
           <p style={{ marginTop: "1.25em" }}>
             <CmId id="sjh-insight-key-line" className="key">
@@ -310,12 +316,12 @@ export default function StartingJobHunting() {
         </CmId>
         <div className="deliverables">
           {c.solution.deliverables.map((d, i) => (
-            <div key={d.num} className="deliverable-item">
+            <CmArrayItem key={d.num} id={`sjh-solution-deliverable-${i}`} className="deliverable-item">
               <CmId id={`sjh-solution-deliverable-${i}-num`} className="num">
                 {d.num}
               </CmId>
               <CmId id={`sjh-solution-deliverable-${i}-text`}>{d.text}</CmId>
-            </div>
+            </CmArrayItem>
           ))}
         </div>
       </section>
@@ -340,12 +346,14 @@ export default function StartingJobHunting() {
             <tbody>
               {c.program.rows.map((row, i) => (
                 <tr key={i}>
-                  <td>
-                    <CmId id={`sjh-program-row-${i}-step`}>{row.step}</CmId>
-                  </td>
-                  <td>
-                    <CmId id={`sjh-program-row-${i}-content`}>{row.content}</CmId>
-                  </td>
+                  <CmArrayItem id={`sjh-program-row-${i}`} style={{ display: "contents" }}>
+                    <td>
+                      <CmId id={`sjh-program-row-${i}-step`}>{row.step}</CmId>
+                    </td>
+                    <td>
+                      <CmId id={`sjh-program-row-${i}-content`}>{row.content}</CmId>
+                    </td>
+                  </CmArrayItem>
                 </tr>
               ))}
             </tbody>
@@ -353,9 +361,9 @@ export default function StartingJobHunting() {
         </div>
         <div className="flow-points">
           {c.program.points.map((p, i) => (
-            <div key={i} className="flow-point">
+            <CmArrayItem key={i} id={`sjh-program-point-${i}`} className="flow-point">
               <CmId id={`sjh-program-point-${i}`}>{p}</CmId>
-            </div>
+            </CmArrayItem>
           ))}
         </div>
       </section>
@@ -377,7 +385,9 @@ export default function StartingJobHunting() {
             <ul className="facilitator-bio">
               {c.facilitator.bio.map((line, i) => (
                 <li key={i}>
-                  <CmId id={`sjh-facilitator-bio-${i}`}>{line}</CmId>
+                  <CmArrayItem id={`sjh-facilitator-bio-${i}`}>
+                    <CmId id={`sjh-facilitator-bio-${i}`}>{line}</CmId>
+                  </CmArrayItem>
                 </li>
               ))}
             </ul>
@@ -395,14 +405,14 @@ export default function StartingJobHunting() {
         </h2>
         <div className="voices">
           {c.voices.items.map((v, i) => (
-            <div key={i} className="voice-card">
+            <CmArrayItem key={i} id={`sjh-voices-item-${i}`} className="voice-card">
               <CmId id={`sjh-voices-item-${i}-school`} className="school">
                 {v.school}
               </CmId>
               <CmId id={`sjh-voices-item-${i}-comment`} className="comment">
                 {v.comment}
               </CmId>
-            </div>
+            </CmArrayItem>
           ))}
         </div>
       </section>
@@ -414,12 +424,14 @@ export default function StartingJobHunting() {
           <tbody>
             {c.info.scheduleRows.map((row, i) => (
               <tr key={i}>
-                <td>
-                  <CmId id={`sjh-info-row-${i}-label`}>{row.label}</CmId>
-                </td>
-                <td>
-                  <CmId id={`sjh-info-row-${i}-value`}>{row.value}</CmId>
-                </td>
+                <CmArrayItem id={`sjh-info-row-${i}`} style={{ display: "contents" }}>
+                  <td>
+                    <CmId id={`sjh-info-row-${i}-label`}>{row.label}</CmId>
+                  </td>
+                  <td>
+                    <CmId id={`sjh-info-row-${i}-value`}>{row.value}</CmId>
+                  </td>
+                </CmArrayItem>
               </tr>
             ))}
           </tbody>
@@ -448,7 +460,9 @@ export default function StartingJobHunting() {
         <ul className="recommend-list">
           {c.recommend.items.map((item, i) => (
             <li key={i}>
-              <CmId id={`sjh-recommend-item-${i}`}>{item}</CmId>
+              <CmArrayItem id={`sjh-recommend-item-${i}`}>
+                <CmId id={`sjh-recommend-item-${i}`}>{item}</CmId>
+              </CmArrayItem>
             </li>
           ))}
         </ul>
@@ -461,14 +475,14 @@ export default function StartingJobHunting() {
         </h2>
         <div className="faq">
           {c.faq.items.map((item, i) => (
-            <div key={i} className="faq-item">
+            <CmArrayItem key={i} id={`sjh-faq-item-${i}`} className="faq-item">
               <CmId id={`sjh-faq-item-${i}-q`} className="faq-q">
                 {item.q}
               </CmId>
               <CmId id={`sjh-faq-item-${i}-a`} className="faq-a">
                 {item.a}
               </CmId>
-            </div>
+            </CmArrayItem>
           ))}
         </div>
       </section>
@@ -482,9 +496,9 @@ export default function StartingJobHunting() {
         </div>
         <div className="meta">
           {c.finalCta.metaItems.map((m, i) => (
-            <CmId key={i} id={`sjh-final-cta-meta-${i}`}>
-              {m}
-            </CmId>
+            <CmArrayItem key={i} id={`sjh-final-cta-meta-${i}`}>
+              <CmId id={`sjh-final-cta-meta-${i}`}>{m}</CmId>
+            </CmArrayItem>
           ))}
         </div>
         <CtaButton
@@ -500,9 +514,9 @@ export default function StartingJobHunting() {
 
       <footer>
         {c.footer.lines.map((line, i) => (
-          <CmId key={i} id={`sjh-footer-line-${i}`}>
-            {line}
-          </CmId>
+          <CmArrayItem key={i} id={`sjh-footer-line-${i}`}>
+            <CmId id={`sjh-footer-line-${i}`}>{line}</CmId>
+          </CmArrayItem>
         ))}
         <CmId id="sjh-footer-copyright">{c.footer.copyright}</CmId>
       </footer>

--- a/client/src/types/home-copy.ts
+++ b/client/src/types/home-copy.ts
@@ -344,6 +344,17 @@ function mergeItems<T>(
   return fallback.map((fb, i) => mergeOne(value[i], fb));
 }
 
+/** 保存データの件数を尊重し、デフォルトより多い場合も保持 */
+function mergeDynamicItems<T>(
+  value: unknown,
+  fallback: T[],
+  mergeOne: (item: unknown, fb: T) => T,
+  emptyFactory: () => T,
+): T[] {
+  if (!Array.isArray(value) || value.length === 0) return fallback;
+  return value.map((item, i) => mergeOne(item, fallback[i] ?? emptyFactory()));
+}
+
 export function mergeHomeCopy(raw: unknown): HomeCopy {
   const base = DEFAULT_HOME_COPY;
   if (!raw || typeof raw !== "object") return base;
@@ -396,7 +407,10 @@ export function mergeHomeCopy(raw: unknown): HomeCopy {
     values: {
       eyebrow: mergeString(values.eyebrow, base.values.eyebrow),
       heading: mergeString(values.heading, base.values.heading),
-      items: mergeItems(values.items, base.values.items, (item, fb) => {
+      items: mergeDynamicItems(
+        values.items,
+        base.values.items,
+        (item, fb) => {
         const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
         return {
           label: mergeString(o.label, fb.label),
@@ -404,64 +418,86 @@ export function mergeHomeCopy(raw: unknown): HomeCopy {
           body: mergeString(o.body, fb.body),
           note: o.note === undefined ? fb.note : mergeString(o.note, fb.note ?? ""),
         };
-      }),
+      },
+        () => ({ label: "", title: "", body: "", note: "" }),
+      ),
     },
     eventFlow: {
       eyebrow: mergeString(eventFlow.eyebrow, base.eventFlow.eyebrow),
       heading: mergeString(eventFlow.heading, base.eventFlow.heading),
-      steps: mergeItems(eventFlow.steps, base.eventFlow.steps, (item, fb) => {
+      steps: mergeDynamicItems(
+        eventFlow.steps,
+        base.eventFlow.steps,
+        (item, fb) => {
         const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
         return {
           title: mergeString(o.title, fb.title),
           time: mergeString(o.time, fb.time),
           description: mergeString(o.description, fb.description),
         };
-      }),
+      },
+        () => ({ title: "", time: "", description: "" }),
+      ),
     },
     voices: {
       eyebrow: mergeString(voices.eyebrow, base.voices.eyebrow),
       heading: mergeString(voices.heading, base.voices.heading),
-      items: mergeItems(voices.items, base.voices.items, (item, fb) => {
+      items: mergeDynamicItems(
+        voices.items,
+        base.voices.items,
+        (item, fb) => {
         const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
         return {
           quote: mergeString(o.quote, fb.quote),
           attribution: mergeString(o.attribution, fb.attribution),
         };
-      }),
+      },
+        () => ({ quote: "", attribution: "" }),
+      ),
     },
     screening: {
       eyebrow: mergeString(screening.eyebrow, base.screening.eyebrow),
       heading: mergeString(screening.heading, base.screening.heading),
       intro: mergeString(screening.intro, base.screening.intro),
-      criteria: mergeItems(screening.criteria, base.screening.criteria, (item, fb) =>
-        mergeString(item, fb),
+      criteria: mergeDynamicItems(
+        screening.criteria,
+        base.screening.criteria,
+        (item, fb) => mergeString(item, fb),
+        () => "",
       ),
       trustNote: mergeString(screening.trustNote, base.screening.trustNote),
     },
     safety: {
       heading: mergeString(safety.heading, base.safety.heading),
       subheading: mergeString(safety.subheading, base.safety.subheading),
-      items: mergeItems(safety.items, base.safety.items, (item, fb) => {
+      items: mergeDynamicItems(
+        safety.items,
+        base.safety.items,
+        (item, fb) => {
         const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
         return {
           title: mergeString(o.title, fb.title),
           description: mergeString(o.description, fb.description),
         };
-      }),
+      },
+        () => ({ title: "", description: "" }),
+      ),
     },
     faq: {
       eyebrow: mergeString(faq.eyebrow, base.faq.eyebrow),
       heading: mergeString(faq.heading, base.faq.heading),
-      items: Array.isArray(faq.items) && faq.items.length > 0
-        ? faq.items.map((item, i) => {
-            const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
-            const fb = base.faq.items[i] ?? { question: "", answer: "" };
-            return {
-              question: mergeString(o.question, fb.question),
-              answer: mergeString(o.answer, fb.answer),
-            };
-          })
-        : base.faq.items,
+      items: mergeDynamicItems(
+        faq.items,
+        base.faq.items,
+        (item, fb) => {
+          const o = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+          return {
+            question: mergeString(o.question, fb.question),
+            answer: mergeString(o.answer, fb.answer),
+          };
+        },
+        () => ({ question: "", answer: "" }),
+      ),
     },
     finalCta: {
       headingLine1: mergeString(finalCta.headingLine1, base.finalCta.headingLine1),


### PR DESCRIPTION
@hiroshimaeasyryo ご確認お願いします！
@rinsakitani ひがさんのほうでmainにmergeしていただいたら、削除・追加可能とした箇所はこちらの表でご確認ください！

## Summary

コンテンツマネージャーのプレビューで、配列項目の追加・削除を行えるようにしました。

- 項目余白（`data-cm-array-id`）クリック → 追加・削除パレット
- 文言フィールド（`data-cm-id`）クリック → 従来どおり編集パレット
- 追加時は選択中の項目をコピーして挿入（確認モーダル付き）
- 表形式など余白クリックが難しい10箇所は、文言編集パレット下部にも追加・削除ボタンを併設

## 追加・削除可能な箇所一覧（全60箇所）

| LP | セクション | 操作の入り方 |
|---|---|---|
| トップ LP (`root`) | Valuesカード | 項目余白クリック |
| トップ LP (`root`) | イベントフロー | 項目余白クリック |
| トップ LP (`root`) | 特徴カード | 項目余白クリック |
| トップ LP (`root`) | 参加者の声 | 項目余白クリック |
| トップ LP (`root`) | Screening 基準 | 項目余白クリック |
| トップ LP (`root`) | 安心ポイント | 項目余白クリック |
| トップ LP (`root`) | FAQ | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | ヒーロー情報行 | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | 共感 · チェックリスト | 項目余白クリック + **文言編集パレット下部** |
| BTOBセミナー (`btob_seminar`) | 構造ループ | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | 体験項目 | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | 持ち帰りカード | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | 対象者リスト | 項目余白クリック + **文言編集パレット下部** |
| BTOBセミナー (`btob_seminar`) | 主催者カード | 項目余白クリック |
| BTOBセミナー (`btob_seminar`) | 開催概要テーブル | 項目余白クリック + **文言編集パレット下部** |
| BTOBセミナー (`btob_seminar`) | FAQ | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | イベント · タグ | 項目余白クリック + **文言編集パレット下部** |
| 自己理解セミナー (`self-reflection`) | 課題リスト | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | コンセプト · タグ | 項目余白クリック + **文言編集パレット下部** |
| 自己理解セミナー (`self-reflection`) | ステップ | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | 体験者の声 | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | 安心ポイント | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | アドバイザー · 経歴 | 項目余白クリック |
| 自己理解セミナー (`self-reflection`) | FAQ | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | イベント情報行 | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | Problem リスト | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | Insight 段落 | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | Solution 成果物 | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | Program 表 | 項目余白クリック + **文言編集パレット下部** |
| 就活スタート (`starting_job_hunting`) | Program · ポイント | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | Facilitator · 経歴 | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | 参加者の声 | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | 開催情報テーブル | 項目余白クリック + **文言編集パレット下部** |
| 就活スタート (`starting_job_hunting`) | おすすめリスト | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | FAQ | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | 最終CTA · メタ | 項目余白クリック |
| 就活スタート (`starting_job_hunting`) | フッター行 | 項目余白クリック |
| 自己スタンス (`self-stance`) | イベント情報行 | 項目余白クリック |
| 自己スタンス (`self-stance`) | 悩みリスト | 項目余白クリック |
| 自己スタンス (`self-stance`) | メリットリスト | 項目余白クリック |
| 自己スタンス (`self-stance`) | Program ステップ | 項目余白クリック + **文言編集パレット下部** |
| 自己スタンス (`self-stance`) | Program · ポイント | 項目余白クリック |
| 自己スタンス (`self-stance`) | Facilitator · 経歴 | 項目余白クリック |
| 自己スタンス (`self-stance`) | 参加者の声 | 項目余白クリック |
| 自己スタンス (`self-stance`) | 開催情報テーブル | 項目余白クリック + **文言編集パレット下部** |
| 自己スタンス (`self-stance`) | おすすめリスト | 項目余白クリック |
| 自己スタンス (`self-stance`) | FAQ | 項目余白クリック |
| 自己スタンス (`self-stance`) | 最終CTA · 段落 | 項目余白クリック + **文言編集パレット下部** |
| 自己スタンス (`self-stance`) | フッター行 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | FV 情報行 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | 共感リスト | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | 得られるもの | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | ワークステップ | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | 当日の流れ · 注記 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | Facilitator · 経歴 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | 参加者の声 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | 開催情報行 | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | おすすめリスト | 項目余白クリック |
| JS自己分析 (`js_self_analysis`) | FAQ | 項目余白クリック |

## Test plan

- [ ] 各LPのプレビューで、項目余白クリックにより追加・削除パレットが開くこと
- [ ] 「前に追加する」「後ろに追加する」で選択項目がコピーされ、確認モーダル後に挿入されること
- [ ] 「項目を削除する」で確認モーダル後に削除されること
- [ ] 表形式10箇所で、文言クリック時に編集パレット下部にも追加・削除ボタンが表示されること
- [ ] 保存後に反映されること
