### PR TITLE
fix: CTAボタンのLINE追加URLをsns_ks2028に変更

### DIFF
--- a/client/src/constants/line-ks-signup.ts
+++ b/client/src/constants/line-ks-signup.ts
@@ -3,7 +3,7 @@
  * クッションページ経由だった導線を直接リンクにする際の単一ソース
  */
 export const LINE_KS_SIGNUP_URL =
-  "https://xp48w7qk.autosns.app/addfriend/s/U2gUDIzwJh/@779ahmbk?free1=sns_ks2027";
+  "https://xp48w7qk.autosns.app/addfriend/s/U2gUDIzwJh/@779ahmbk?free1=sns_ks2028";
 
 /** /campaign2603 用のLINE追加URL */
 export const LINE_CAMPAIGN2603_SIGNUP_URL =


### PR DESCRIPTION
## Summary
- CTAボタンのLINE追加URLのトラッキングパラメータを変更
- `sns_ks2027` → `sns_ks2028`
- META広告配信に伴うパラメータ更新

## 変更ファイル
- `client/src/constants/line-ks-signup.ts`

## 影響範囲
- Meta Pixelのコンバージョン計測への影響なし（`fbq('track', 'Lead')` はクリックイベントで発火するため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)