### PR TITLE
CTAボタンの編集単位を親タグに統一

### DIFF
--- a/client/public/content/manifest.json
+++ b/client/public/content/manifest.json
@@ -2,11 +2,11 @@
   "slugs": [
     "btob_seminar",
     "campaign2603",
+    "js_self_analysis",
     "main",
     "root",
     "self-reflection",
     "self-stance",
-    "starting_job_hunting",
-    "js_self_analysis"
+    "starting_job_hunting"
   ]
 }

--- a/client/src/hooks/useCmPreviewPage.ts
+++ b/client/src/hooks/useCmPreviewPage.ts
@@ -11,11 +11,14 @@ import {
   subscribePreviewStorage,
 } from "@/lib/content-manager/preview-storage";
 import {
+  CM_CTA_BUTTON_ANCHOR_SELECTOR,
+  CM_CTA_BUTTON_LABEL_SELECTOR,
   CM_PREVIEW_SELECTABLE_SELECTOR,
   getSelectableId,
   getSelectableKind,
   getSelectableLabel,
   isAccordionToggleTarget,
+  normalizeClickStart,
   openAccordionHostForElement,
   resolveClickTarget,
 } from "@/lib/content-manager/cm-preview-select";
@@ -80,6 +83,19 @@ export function useCmPreviewPage({ slug, onDraft, onScrollToId }: Options): bool
         cursor: pointer !important;
         outline: none !important;
       }
+      ${CM_CTA_BUTTON_ANCHOR_SELECTOR} ${CM_CTA_BUTTON_LABEL_SELECTOR} {
+        cursor: inherit !important;
+        outline: none !important;
+      }
+      ${CM_CTA_BUTTON_ANCHOR_SELECTOR} {
+        cursor: pointer !important;
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+        transition: outline-color 0.15s ease;
+      }
+      ${CM_CTA_BUTTON_ANCHOR_SELECTOR}:hover {
+        outline-color: rgba(212, 132, 75, 0.55) !important;
+      }
     `;
     document.head.appendChild(style);
 
@@ -87,13 +103,14 @@ export function useCmPreviewPage({ slug, onDraft, onScrollToId }: Options): bool
       // FAQ 開閉ボタンなど UI 操作は選択処理を通さない（React onClick を妨げない）
       if (isAccordionToggleTarget(e.target)) return;
 
+      const clickStart = normalizeClickStart(e.target);
       const target = resolveClickTarget(e.target);
       if (!target) return;
       e.preventDefault();
       e.stopPropagation();
-      const id = getSelectableId(target);
+      const id = getSelectableId(target, clickStart);
       const label = getSelectableLabel(target);
-      const selectKind = getSelectableKind(target);
+      const selectKind = getSelectableKind(target, clickStart);
       document.querySelectorAll("[data-cm-active]").forEach((el) => {
         el.removeAttribute("data-cm-active");
       });

--- a/client/src/lib/content-manager/cm-preview-select-cta.test.ts
+++ b/client/src/lib/content-manager/cm-preview-select-cta.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getSelectableId,
+  getSelectableKind,
+  isAutoSelectableId,
+  normalizeClickStart,
+  resolveClickTarget,
+} from "./cm-preview-select";
+
+type CtaFixture = {
+  lp: string;
+  fieldId: string;
+  html: string;
+};
+
+/** 各 LP の CTA ボタン DOM（実装に沿った最小構造） */
+const CTA_FIXTURES: CtaFixture[] = [
+  // Home LP — data-cm-id は a 自体
+  {
+    lp: "home",
+    fieldId: "nav-header-cta",
+    html: `<a href="https://line.me" data-cm-id="nav-header-cta" class="header-cta">LINEで相談する</a>`,
+  },
+  {
+    lp: "home",
+    fieldId: "hero-sticky-cta",
+    html: `<a href="https://line.me" data-cm-id="hero-sticky-cta" class="sticky-cta">無料相談はこちら</a>`,
+  },
+  {
+    lp: "home",
+    fieldId: "hero-cta",
+    html: `<a href="https://line.me" data-cm-id="hero-cta" class="cta-btn">エントリーする</a>`,
+  },
+  {
+    lp: "home",
+    fieldId: "about-cta",
+    html: `<a href="https://line.me" data-cm-id="about-cta" class="about-cta">詳しく見る</a>`,
+  },
+  // Starting Job Hunting
+  {
+    lp: "starting_job_hunting",
+    fieldId: "sjh-header-cta-label",
+    html: `<a href="https://line.me" class="header-cta">
+      <svg class="line-icon" aria-hidden="true"><circle cx="8" cy="8" r="8"/></svg>
+      <span data-cm-id="sjh-header-cta-label" class="header-cta-label header-cta-label--desktop">Desktop CTA</span>
+      <span data-cm-id="sjh-header-cta-label-mobile" class="header-cta-label header-cta-label--mobile" style="display:none">Mobile CTA</span>
+    </a>`,
+  },
+  {
+    lp: "starting_job_hunting",
+    fieldId: "sjh-hero-primary-cta-label",
+    html: `<a href="https://line.me" class="cta-btn">
+      <svg class="line-icon"><circle cx="8" cy="8" r="8"/></svg>
+      <span data-cm-id="sjh-hero-primary-cta-label">FV CTA</span>
+    </a>`,
+  },
+  {
+    lp: "starting_job_hunting",
+    fieldId: "sjh-mid-cta-label",
+    html: `<a href="https://line.me" class="cta-btn"><span data-cm-id="sjh-mid-cta-label">中間CTA</span></a>`,
+  },
+  {
+    lp: "starting_job_hunting",
+    fieldId: "sjh-sticky-cta-label",
+    html: `<a href="https://line.me" class="cta-btn"><span data-cm-id="sjh-sticky-cta-label">固定CTA</span></a>`,
+  },
+  // Self Stance
+  {
+    lp: "self_stance",
+    fieldId: "ss-sticky-cta-label",
+    html: `<div data-cm-id="ss-sticky-cta-bar" class="sticky">
+      <a href="https://line.me">
+        <svg class="line-icon"><circle cx="8" cy="8" r="8"/></svg>
+        <span data-cm-id="ss-sticky-cta-label">固定CTA</span>
+      </a>
+    </div>`,
+  },
+  {
+    lp: "self_stance",
+    fieldId: "ss-header-cta-label",
+    html: `<a href="https://line.me" class="header-btn">
+      <span data-cm-id="ss-header-cta-label">ヘッダーCTA</span>
+      <svg class="line-icon"><circle cx="8" cy="8" r="8"/></svg>
+    </a>`,
+  },
+  {
+    lp: "self_stance",
+    fieldId: "ss-hero-primary-cta-label",
+    html: `<a href="https://line.me" class="btn-line">
+      <svg><circle cx="8" cy="8" r="8"/></svg>
+      <span data-cm-id="ss-hero-primary-cta-label">FV CTA</span>
+    </a>`,
+  },
+  // JS Self Analysis
+  {
+    lp: "js_self_analysis",
+    fieldId: "jsa-floating-cta-label",
+    html: `<a href="https://line.me">
+      <svg><circle cx="8" cy="8" r="8"/></svg>
+      <span data-cm-id="jsa-floating-cta-label">固定CTA</span>
+    </a>`,
+  },
+  {
+    lp: "js_self_analysis",
+    fieldId: "jsa-hero-cta-label",
+    html: `<a href="https://line.me" class="hero-cta">
+      <svg><circle cx="8" cy="8" r="8"/></svg>
+      <span data-cm-id="jsa-hero-cta-label">FV CTA</span>
+    </a>`,
+  },
+  {
+    lp: "js_self_analysis",
+    fieldId: "jsa-final-cta-cta-label",
+    html: `<a href="https://line.me" class="btn-line"><span data-cm-id="jsa-final-cta-cta-label">最終CTA</span></a>`,
+  },
+  // Self Reflection
+  {
+    lp: "self_reflection",
+    fieldId: "sr-hero-cta-label",
+    html: `<a href="https://line.me" class="cta-btn large"><span data-cm-id="sr-hero-cta-label">ヒーローCTA</span></a>`,
+  },
+  {
+    lp: "self_reflection",
+    fieldId: "sr-cause-cta-label",
+    html: `<a href="https://line.me" class="cta-btn"><span data-cm-id="sr-cause-cta-label">原因CTA</span></a>`,
+  },
+  {
+    lp: "self_reflection",
+    fieldId: "sr-closing-cta-label",
+    html: `<a href="https://line.me" class="cta-btn dark-bg large"><span data-cm-id="sr-closing-cta-label">最終CTA</span></a>`,
+  },
+  // BTOB Seminar
+  {
+    lp: "btob_seminar",
+    fieldId: "btob-header-cta-label",
+    html: `<a href="https://example.com" class="header-cta"><span data-cm-id="btob-header-cta-label">ヘッダーCTA</span></a>`,
+  },
+  {
+    lp: "btob_seminar",
+    fieldId: "btob-hero-primary-cta-label",
+    html: `<a href="https://example.com" class="cta-primary"><span data-cm-id="btob-hero-primary-cta-label">ヒーローCTA</span></a>`,
+  },
+  {
+    lp: "btob_seminar",
+    fieldId: "btob-mid-cta-label",
+    html: `<a href="https://example.com" class="cta-light"><span data-cm-id="btob-mid-cta-label">中段CTA</span></a>`,
+  },
+  {
+    lp: "btob_seminar",
+    fieldId: "btob-final-cta-label",
+    html: `<a href="https://example.com" class="cta-light"><span data-cm-id="btob-final-cta-label">最終CTA</span></a>`,
+  },
+];
+
+function mount(html: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+function getAnchor(container: HTMLElement): HTMLAnchorElement {
+  const anchor = container.querySelector("a[href]");
+  if (!(anchor instanceof HTMLAnchorElement)) {
+    throw new Error("CTA anchor not found");
+  }
+  return anchor;
+}
+
+function getLabel(container: HTMLElement): HTMLElement {
+  const label = container.querySelector("[data-cm-id$='-cta-label'], [data-cm-id$='-cta-label-mobile'], a[data-cm-id]");
+  if (!(label instanceof HTMLElement)) {
+    throw new Error("CTA label not found");
+  }
+  return label;
+}
+
+function getIcon(container: HTMLElement): SVGElement | null {
+  const svg = container.querySelector("svg");
+  return svg instanceof SVGElement ? svg : null;
+}
+
+function assertEditable(clickTarget: EventTarget | null, expectedFieldId: string): void {
+  const start = normalizeClickStart(clickTarget);
+  const target = resolveClickTarget(clickTarget);
+  expect(target, `resolveClickTarget returned null for field ${expectedFieldId}`).not.toBeNull();
+
+  const id = getSelectableId(target!, start);
+  const kind = getSelectableKind(target!, start);
+
+  expect(kind, `expected field kind for ${expectedFieldId}, got ${kind} (id=${id})`).toBe("field");
+  expect(isAutoSelectableId(id), `auto-selectable id for ${expectedFieldId}: ${id}`).toBe(false);
+  expect(id).toBe(expectedFieldId);
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("cm-preview-select CTA buttons (all LPs)", () => {
+  for (const fixture of CTA_FIXTURES) {
+    describe(`${fixture.lp} · ${fixture.fieldId}`, () => {
+      it("ラベル文字クリックで field として選択できる", () => {
+        const container = mount(fixture.html);
+        const label = getLabel(container);
+        assertEditable(label, fixture.fieldId);
+      });
+
+      it("a 要素の余白クリックで field として選択できる", () => {
+        const container = mount(fixture.html);
+        const anchor = getAnchor(container);
+        assertEditable(anchor, fixture.fieldId);
+      });
+
+      it("アイコン（SVG）クリックで field として選択できる", () => {
+        const container = mount(fixture.html);
+        const icon = getIcon(container);
+        if (!icon) return;
+        assertEditable(icon, fixture.fieldId);
+      });
+
+      it("内側 span を直接選択単位にしない（親 a を返す）", () => {
+        const container = mount(fixture.html);
+        const label = getLabel(container);
+        if (label.tagName === "A") return;
+        const target = resolveClickTarget(label);
+        expect(target?.tagName).toBe("A");
+        expect(target).not.toBe(label);
+      });
+    });
+  }
+
+  it("SJH ヘッダー: mobile ラベルクリックで mobile フィールド ID を返す", () => {
+    const container = mount(`
+      <a href="https://line.me" class="header-cta">
+        <span data-cm-id="sjh-header-cta-label" class="header-cta-label--desktop" style="display:none">Desktop</span>
+        <span data-cm-id="sjh-header-cta-label-mobile" class="header-cta-label--mobile">Mobile</span>
+      </a>
+    `);
+    const mobile = container.querySelector("[data-cm-id='sjh-header-cta-label-mobile']")!;
+    assertEditable(mobile, "sjh-header-cta-label-mobile");
+  });
+});

--- a/client/src/lib/content-manager/cm-preview-select.ts
+++ b/client/src/lib/content-manager/cm-preview-select.ts
@@ -66,8 +66,67 @@ function buildElementPath(el: HTMLElement): string {
   return parts.join("/");
 }
 
+/** CTAボタン内ラベル（親 a と一体で編集する span） */
+export const CM_CTA_BUTTON_LABEL_SELECTOR =
+  '[data-cm-id$="-cta-label"], [data-cm-id$="-cta-label-mobile"]';
+
+/** 内側ラベルを持つ CTA ボタン（編集プレビューで親 a を選択単位とする） */
+export const CM_CTA_BUTTON_ANCHOR_SELECTOR = `a[href]:has(${CM_CTA_BUTTON_LABEL_SELECTOR})`;
+
 /** プレビューで要素選択の対象外（UI 操作用） */
 export const CM_PREVIEW_IGNORE_SELECT_SELECTOR = "[data-faq-toggle], [data-cm-no-select]";
+
+function isCtaButtonLabelId(id: string): boolean {
+  return /-cta-label(?:-mobile)?$/.test(id);
+}
+
+function isCtaButtonLabelElement(el: Element): el is HTMLElement {
+  if (!(el instanceof HTMLElement)) return false;
+  const id = el.getAttribute("data-cm-id");
+  return id != null && isCtaButtonLabelId(id);
+}
+
+function getCtaButtonLabelElements(anchor: HTMLAnchorElement): HTMLElement[] {
+  return [...anchor.querySelectorAll("[data-cm-id]")].filter(isCtaButtonLabelElement);
+}
+
+function resolveCtaButtonAnchor(start: HTMLElement): HTMLAnchorElement | null {
+  const anchor = start.closest("a[href]");
+  if (!(anchor instanceof HTMLAnchorElement)) return null;
+  if (!anchor.contains(start)) return null;
+  return getCtaButtonLabelElements(anchor).length > 0 ? anchor : null;
+}
+
+function resolveCtaButtonFieldId(anchor: HTMLAnchorElement, start: HTMLElement): string {
+  const labels = getCtaButtonLabelElements(anchor);
+  for (const label of labels) {
+    if (label === start || label.contains(start)) {
+      return label.getAttribute("data-cm-id")!;
+    }
+  }
+  if (labels.length === 1) {
+    return labels[0].getAttribute("data-cm-id")!;
+  }
+  const visible = labels.find((el) => {
+    const style = window.getComputedStyle(el);
+    return style.display !== "none" && style.visibility !== "hidden";
+  });
+  return (visible ?? labels[0]).getAttribute("data-cm-id")!;
+}
+
+export function normalizeClickStart(raw: EventTarget | null): HTMLElement | null {
+  if (!(raw instanceof Element)) return null;
+  if (raw.closest(CM_PREVIEW_IGNORE_SELECT_SELECTOR)) return null;
+
+  let start: Element | null = raw;
+  if (start instanceof SVGElement || start.closest(SKIP_ANCESTOR_SELECTOR) === start) {
+    start =
+      start.closest("button, a[href], [data-cm-id], [data-cm-array-id], summary, label") ??
+      start.parentElement;
+  }
+
+  return start instanceof HTMLElement ? start : null;
+}
 
 /** プレビューで開閉トグルとして扱う（選択ハンドラを通さない） */
 export function isAccordionToggleTarget(raw: EventTarget | null): boolean {
@@ -84,17 +143,12 @@ export function openAccordionHostForElement(el: Element): void {
 }
 
 export function resolveClickTarget(raw: EventTarget | null): HTMLElement | null {
-  if (!(raw instanceof Element)) return null;
-  if (raw.closest(CM_PREVIEW_IGNORE_SELECT_SELECTOR)) return null;
+  const start = normalizeClickStart(raw);
+  if (!start) return null;
 
-  let start: Element | null = raw;
-  if (start instanceof SVGElement || start.closest(SKIP_ANCESTOR_SELECTOR) === start) {
-    start =
-      start.closest("button, a[href], [data-cm-id], [data-cm-array-id], summary, label") ??
-      start.parentElement;
-  }
-
-  if (!(start instanceof HTMLElement)) return null;
+  // CTAボタン: 内側 span ではなく親 a を編集単位とする
+  const ctaAnchor = resolveCtaButtonAnchor(start);
+  if (ctaAnchor) return ctaAnchor;
 
   // 文言フィールド（data-cm-id）を最優先
   let el: HTMLElement | null = start;
@@ -120,15 +174,27 @@ export function resolveClickTarget(raw: EventTarget | null): HTMLElement | null 
   return null;
 }
 
-export function getSelectableKind(el: HTMLElement): "field" | "array" | "auto" {
+export function getSelectableKind(
+  el: HTMLElement,
+  clickStart?: HTMLElement | null,
+): "field" | "array" | "auto" {
   if (el.hasAttribute("data-cm-array-id")) return "array";
   if (el.hasAttribute("data-cm-id")) return "field";
+  if (el instanceof HTMLAnchorElement && clickStart && getCtaButtonLabelElements(el).length > 0) {
+    return "field";
+  }
   return "auto";
 }
 
-export function getSelectableId(el: HTMLElement): string {
+export function getSelectableId(el: HTMLElement, clickStart?: HTMLElement | null): string {
   if (el.hasAttribute("data-cm-array-id")) {
     return el.getAttribute("data-cm-array-id")!;
+  }
+  if (el instanceof HTMLAnchorElement && clickStart) {
+    const labels = getCtaButtonLabelElements(el);
+    if (labels.length > 0) {
+      return resolveCtaButtonFieldId(el, clickStart);
+    }
   }
   const cmId = el.getAttribute("data-cm-id");
   if (cmId) return cmId;


### PR DESCRIPTION
@hiroshimaeasyryo 
**Summary**
・cm-preview-select で、CTA ボタン（a href 内に -cta-label の data-cm-id を持つ span がある構造）を 親 <a> タグ1つ の編集単位として解決するように変更
・内側の <span> は編集プレビューで個別選択できず、ラベル・アイコン・余白のどこをクリックしても同じ CTA フィールド（文言・URL）が編集パレットに開く
・以前はアイコンや余白クリック時に auto:a:...（ReadOnly）になっていたが、正しい CTA フィールドとして編集可能に
・useCmPreviewPage の CSS を調整し、CTA 内 span のホバー枠を無効化して親 <a> 全体にハイライトを表示
・cm-preview-select-cta.test.ts を追加し、全 LP の CTA 選択挙動をユニットテストで検証

**Test plan**
- [ ] コンテンツマネージャーの編集プレビューで、各 LP の CTA ボタンをクリックし、<a> 全体が1つの編集単位として選択されること
- [ ]  CTA 内の文言（span）をクリックしても span 単体では選択されず、親 <a> が選ばれ編集パレットが開くこと
- [ ]  CTA のアイコンや余白をクリックしても、文言・URL の編集パレットが開くこと（ReadOnly にならないこと）
- [ ]  CTA 以外の通常テキスト要素の選択・編集が従来どおり動くこと
- [ ]  pnpm test -- client/src/lib/content-manager/cm-preview-select-cta.test.ts が通ること