### PR TITLE
feat: 学生の参加審査セクションをLPに追加

### DIFF
--- a/client/src/lib/content-manager/home-copy-elements.ts
+++ b/client/src/lib/content-manager/home-copy-elements.ts
@@ -155,6 +155,16 @@ export const HOME_COPY_ELEMENTS: ElementDefinition[] = [
 
   def("screening-trust", "Screening 運営元テキスト"),
 
+  def("student-screening-eyebrow", "学生参加審査 ラベル"),
+
+  def("student-screening-heading", "学生参加審査 見出し"),
+
+  def("student-screening-intro", "学生参加審査 リード文"),
+
+  ...indexedSimple("student-screening-criterion", "学生参加審査 基準", 3),
+
+  def("student-screening-note", "学生参加審査 補足テキスト"),
+
   def("safety-heading", "安全開催 見出し"),
 
   def("safety-subheading", "安全開催 サブ見出し"),
@@ -171,7 +181,7 @@ export const HOME_COPY_ELEMENTS: ElementDefinition[] = [
 
   def("faq-heading", "FAQ 見出し"),
 
-  ...indexedFields("faq-item", "FAQ", 8, [
+  ...indexedFields("faq-item", "FAQ", 9, [
 
     { suffix: "question", label: "質問" },
 
@@ -226,6 +236,8 @@ const HOME_COPY_FIELD_PATTERNS: RegExp[] = [
   /^faq-item-\d+-(question|answer)$/,
 
   /^screening-criterion-\d+$/,
+
+  /^student-screening-criterion-\d+$/,
 
 ];
 

--- a/client/src/lib/content-manager/home-copy-text-bindings.ts
+++ b/client/src/lib/content-manager/home-copy-text-bindings.ts
@@ -337,6 +337,54 @@ export function resolveHomeTextBinding(sectionId: string, copy: HomeCopy): HomeT
     };
   }
 
+  if (sectionId === "student-screening-eyebrow") {
+    return {
+      text: copy.studentScreening.eyebrow,
+      multiline: false,
+      rows: 1,
+      applyText: (p, v) => ({ ...p, studentScreening: { ...p.studentScreening, eyebrow: v } }),
+    };
+  }
+  if (sectionId === "student-screening-heading") {
+    return {
+      text: copy.studentScreening.heading,
+      multiline: true,
+      rows: 2,
+      applyText: (p, v) => ({ ...p, studentScreening: { ...p.studentScreening, heading: v } }),
+    };
+  }
+  if (sectionId === "student-screening-intro") {
+    return {
+      text: copy.studentScreening.intro,
+      multiline: true,
+      rows: 6,
+      applyText: (p, v) => ({ ...p, studentScreening: { ...p.studentScreening, intro: v } }),
+    };
+  }
+  if (sectionId === "student-screening-note") {
+    return {
+      text: copy.studentScreening.note,
+      multiline: true,
+      rows: 4,
+      applyText: (p, v) => ({ ...p, studentScreening: { ...p.studentScreening, note: v } }),
+    };
+  }
+
+  const studentCriterionIdx = parseIndexedId(sectionId, "student-screening-criterion");
+  if (studentCriterionIdx !== null && copy.studentScreening.criteria[studentCriterionIdx] !== undefined) {
+    const i = studentCriterionIdx;
+    return {
+      text: copy.studentScreening.criteria[i],
+      multiline: false,
+      rows: 2,
+      applyText: (p, v) => {
+        const criteria = [...p.studentScreening.criteria];
+        criteria[i] = v;
+        return { ...p, studentScreening: { ...p.studentScreening, criteria } };
+      },
+    };
+  }
+
   if (sectionId === "safety-heading") {
     return {
       text: copy.safety.heading,

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -7,7 +7,7 @@
    - タイポグラフィ: Shippori Mincho (見出し) + Zen Kaku Gothic New (本文)
 */
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, type ReactNode } from "react";
 import { useSmoothScroll } from "@/hooks/useSmoothScroll";
 import { useCmPreviewPage } from "@/hooks/useCmPreviewPage";
 import { CmArrayItem } from "@/components/contents-manager/CmId";
@@ -61,6 +61,37 @@ function splitCampaign2603Notice(raw: string): { title: string; body: string } {
   const title = firstNewline >= 0 ? trimmed.slice(0, firstNewline).trim() : trimmed;
   const body = firstNewline >= 0 ? trimmed.slice(firstNewline + 1).trim() : "";
   return { title, body };
+}
+
+/** FAQ回答内のページ内リンク記法 `[表示テキスト](#anchor)` */
+const FAQ_ANCHOR_LINK_PATTERN = /\[([^\]\n]+)\]\((#[A-Za-z0-9_-]+)\)/g;
+
+/**
+ * FAQ回答をレンダリングする。
+ * コンテンツ管理画面ではプレーンテキストで編集させたいため、
+ * リッチテキストではなくページ内アンカーのみを対象にした最小の記法で扱う。
+ */
+function renderFaqAnswer(answer: string): ReactNode {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  // 共有の正規表現は lastIndex が持ち越されるため、実行のたびに複製する
+  const pattern = new RegExp(FAQ_ANCHOR_LINK_PATTERN.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(answer)) !== null) {
+    const start = match.index;
+    if (start > cursor) parts.push(answer.slice(cursor, start));
+    parts.push(
+      <a key={start} href={match[2]} className="text-lp-primary underline underline-offset-2">
+        {match[1]}
+      </a>,
+    );
+    cursor = start + match[0].length;
+  }
+
+  if (parts.length === 0) return answer;
+  if (cursor < answer.length) parts.push(answer.slice(cursor));
+  return parts;
 }
 
 export interface HomeProps {
@@ -893,6 +924,42 @@ export default function Home({ lpSlug }: HomeProps) {
         </div>
       </section>
 
+      {/* Student Screening Section — 企業基準セクションと同じ構成で「企業も学生も同じ土俵」を示す */}
+      <section id="student-screening" className="py-24 px-8 md:px-6">
+        <div className="max-w-2xl mx-auto">
+          <div className="text-center mb-12 opacity-0 animate-fadeUp" style={{ animationFillMode: 'forwards' }}>
+            <p className="text-xs font-medium text-lp-primary uppercase tracking-widest mb-2" data-cm-id="student-screening-eyebrow" style={cms("student-screening-eyebrow")}>{homeCopy.studentScreening.eyebrow}</p>
+            <h2 className="text-3xl md:text-4xl font-bold text-lp-text-heading leading-tight whitespace-pre-line" style={cms("student-screening-heading", MINCHO_STYLE)} data-cm-id="student-screening-heading">
+              {homeCopy.studentScreening.heading}
+            </h2>
+          </div>
+          <div className="mx-6 md:mx-0">
+            <div className="opacity-0 animate-fadeUp" style={{ animationDelay: '0.12s', animationFillMode: 'forwards' }}>
+              <p className="text-sm md:text-base text-lp-text-heading leading-loose text-left md:text-center mb-9 whitespace-pre-line" data-cm-id="student-screening-intro" style={cms("student-screening-intro")}>
+                {homeCopy.studentScreening.intro}
+              </p>
+            </div>
+            <div className="space-y-3 mb-9">
+            {homeCopy.studentScreening.criteria.map((item, i) => (
+              <div key={i} className="flex items-start gap-3 p-4 bg-white border border-lp-border rounded-2xl opacity-0 animate-fadeUp" style={{ animationDelay: `${0.12 + i * 0.12}s`, animationFillMode: 'forwards', borderWidth: '0.5px' }}>
+                <div className="flex-shrink-0 w-7 h-7 rounded-full bg-lp-bg-warm flex items-center justify-center text-lp-primary mt-0.5">
+                  <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M13 4L6 11L3 8"/>
+                  </svg>
+                </div>
+                <p className="text-sm text-lp-text-heading pt-0.5" data-cm-id={`student-screening-criterion-${i}`} style={cms(`student-screening-criterion-${i}`)}>{item}</p>
+              </div>
+            ))}
+            </div>
+            <div className="p-6 bg-lp-bg-warm rounded-2xl text-center opacity-0 animate-fadeUp" style={{ animationDelay: '0.6s', animationFillMode: 'forwards' }} data-cm-id="student-screening-note">
+              <p className="text-sm text-lp-text-heading whitespace-pre-line" style={cms("student-screening-note")}>
+                {homeCopy.studentScreening.note}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* Event Overview Section */}
       <section className="py-24 px-6 bg-lp-bg-warm">
         <div className="max-w-2xl mx-auto">
@@ -988,7 +1055,7 @@ export default function Home({ lpSlug }: HomeProps) {
                         data-cm-id={`faq-item-${i}-answer`}
                         style={cms(`faq-item-${i}-answer`)}
                       >
-                        {item.answer}
+                        {renderFaqAnswer(item.answer)}
                       </div>
                     )}
                   </CmArrayItem>
@@ -1019,7 +1086,7 @@ export default function Home({ lpSlug }: HomeProps) {
                   data-cm-id={`faq-item-${i}-answer`}
                   style={cms(`faq-item-${i}-answer`)}
                 >
-                  {item.answer}
+                  {renderFaqAnswer(item.answer)}
                 </div>
               </details>
               </CmArrayItem>

--- a/client/src/types/home-copy.ts
+++ b/client/src/types/home-copy.ts
@@ -78,6 +78,13 @@ export interface HomeCopy {
     criteria: string[];
     trustNote: string;
   };
+  studentScreening: {
+    eyebrow: string;
+    heading: string;
+    intro: string;
+    criteria: string[];
+    note: string;
+  };
   safety: {
     heading: string;
     subheading: string;
@@ -234,6 +241,20 @@ export const DEFAULT_HOME_COPY: HomeCopy = {
     trustNote:
       "運営元は、マイナビ出資企業である株式会社ワークアズライフ。\nマイナビが実現できない深い部分にこだわった就活支援を行っています。\n上場企業も参加する、信頼のあるイベントです。",
   },
+  studentScreening: {
+    // 企業側の Screening と同一セクションに見えないよう、ラベル文言で区別する
+    eyebrow: "Student Screening",
+    heading: "学生のみなさんにも、\n参加いただく基準があります。",
+    intro:
+      "KANPAI就活では、より良い出会いの場を作るため、\n参加企業の皆様と同様に、学生の皆さんにも\n「参加審査」を受けていただいています。\n\nと言っても、学歴や実績は一切見ません。\n大切にしているのは、次の3つの姿勢です。",
+    criteria: [
+      "等身大で自分のことを話そうとする姿勢",
+      "人とのつながりを大切にできる姿勢",
+      "企業の方と本音で向き合おうとする姿勢",
+    ],
+    note:
+      "参加審査は30分・オンラインで実施します。\n面接のような準備は不要ですので、リラックスしてご参加ください。\n\n参加審査 兼 事前説明は、平日17時〜／19時〜でほぼ毎日実施中です。",
+  },
   safety: {
     heading: "安全開催のための取り組み",
     subheading: "安心して参加いただくために、以下のルールを設けています。",
@@ -277,6 +298,11 @@ export const DEFAULT_HOME_COPY: HomeCopy = {
         question: "当日エントリーや選考を強要されませんか？",
         answer:
           "一切ありません。対話を楽しんでいただくことが目的です。気になる企業があれば、その後のつながり方はあなた次第です。",
+      },
+      {
+        question: "応募すれば必ず参加できますか？",
+        answer:
+          "ご応募後は、30分ほどの「参加審査 兼 事前説明」を受けていただきます。学歴や実績は見ませんので、ご安心ください。詳しくは「[学生のみなさんにも、参加いただく基準があります](#student-screening)」をご覧ください。",
       },
       {
         question: "服装はスーツですか？",
@@ -370,6 +396,7 @@ export function mergeHomeCopy(raw: unknown): HomeCopy {
   const eventFlow = (c.eventFlow && typeof c.eventFlow === "object" ? c.eventFlow : {}) as Record<string, unknown>;
   const voices = (c.voices && typeof c.voices === "object" ? c.voices : {}) as Record<string, unknown>;
   const screening = (c.screening && typeof c.screening === "object" ? c.screening : {}) as Record<string, unknown>;
+  const studentScreening = (c.studentScreening && typeof c.studentScreening === "object" ? c.studentScreening : {}) as Record<string, unknown>;
   const safety = (c.safety && typeof c.safety === "object" ? c.safety : {}) as Record<string, unknown>;
   const faq = (c.faq && typeof c.faq === "object" ? c.faq : {}) as Record<string, unknown>;
   const finalCta = (c.finalCta && typeof c.finalCta === "object" ? c.finalCta : {}) as Record<string, unknown>;
@@ -466,6 +493,15 @@ export function mergeHomeCopy(raw: unknown): HomeCopy {
         () => "",
       ),
       trustNote: mergeString(screening.trustNote, base.screening.trustNote),
+    },
+    studentScreening: {
+      eyebrow: mergeString(studentScreening.eyebrow, base.studentScreening.eyebrow),
+      heading: mergeString(studentScreening.heading, base.studentScreening.heading),
+      intro: mergeString(studentScreening.intro, base.studentScreening.intro),
+      criteria: mergeItems(studentScreening.criteria, base.studentScreening.criteria, (item, fb) =>
+        mergeString(item, fb),
+      ),
+      note: mergeString(studentScreening.note, base.studentScreening.note),
     },
     safety: {
       heading: mergeString(safety.heading, base.safety.heading),


### PR DESCRIPTION
## 概要

「学生にも参加審査がある」ことを伝えるブロックを LP に追加しました。挿入コピー案（`学生参加審査ブロック_挿入コピー案.md`）をもとに実装しています。

## 挿入位置

企業基準セクション「すべての企業に、私たちの基準があります。」の**直後**。

コピー案には「よくあるご質問の直前」との記載もありましたが、実際には両者の間に「安全開催のための取り組み」セクションが存在します。案の意図（「企業基準セクションと学生審査セクションが縦に並ぶため」）を優先し、企業基準セクションの直後に配置しました。

## 変更内容

- `studentScreening` を `HomeCopy` に追加（型・デフォルト文言・マージ処理）
- アイキャッチラベルは `Student Screening`（表示は `STUDENT SCREENING`）とし、企業側の `SCREENING` と区別
- チェックリストのアイコン・枠線・余白・アニメーション遅延は企業基準セクションと同一のマークアップ。背景色のみ白 → ベース色にして視覚的に分離
- FAQ に「応募すれば必ず参加できますか？」を追加し、新セクションへ誘導
- FAQ 回答内の `[テキスト](#anchor)` をページ内リンクとして描画する処理を追加（既存の `useSmoothScroll` に乗る）
- コンテンツ管理画面から全項目を編集できるよう要素定義・テキストバインディングを登録

## 判断が必要だった点

コピー案が追記対象とした FAQ「応募すれば必ず参加できますか？」は**既存 LP に存在しませんでした**。そのため既存回答への追記ではなく、この質問を新規 Q&A として「当日エントリーや選考を強要されませんか？」の直後に追加し、案の追記文を回答本文にしています。

補足ボックスの「参加審査 兼 事前説明は、平日17時〜／19時〜でほぼ毎日実施中です。」は運用状況で変わる可変情報のため、コンテンツ管理画面から編集できるようにしてあります（`学生参加審査 補足テキスト`）。

## 確認したこと

- `pnpm check`: 本 PR による新規エラーなし（既存の 7 件は `main` 時点で発生しているもので、本変更とは無関係）
- dev サーバーの実ページで、新セクションの文言・チェックリスト 3 件・補足ボックス、FAQ の新項目とアンカーリンク（`href="#student-screening"` / リンク先要素の存在）を DOM 上で確認。コンソールエラーなし
- なお、この環境ではブラウザペインが非表示状態のままでフェードインアニメーションが発火せず、スクリーンショットが白紙になるため、**見た目のピクセル単位の確認は未実施**です。マージ前に一度ローカルで目視いただけると安心です

🤖 Generated with [Claude Code](https://claude.com/claude-code)